### PR TITLE
add maven-compiler-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,11 @@
 		<spring-boot-dependencies.version>2.4.4</spring-boot-dependencies.version>
 		<spring-test.version>5.2.0.RELEASE</spring-test.version>
 		<spring-boot-maven-plugin.version>2.2.0.RELEASE</spring-boot-maven-plugin.version>
-	</properties>
+
+        <!-- Maven -->
+        <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
+
+    </properties>
 		<dependencyManagement>
 		<dependencies>
 			<dependency>
@@ -138,6 +142,14 @@
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
                 <version>3.1.1</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
+                <configuration>
+                    <release>11</release>
+                </configuration>
             </plugin>
 		</plugins>
 	</build>


### PR DESCRIPTION
whilst setting up the concourse pipeline an error occurs in the [build-test-analyse job](https://ci.sandbox.aws.chdev.org/teams/development/pipelines/officer-delta-processor/jobs/build-test-analyse/builds/4) 

Think we need to add the maven-compiler-plugin as per this [Baeldung guide](https://www.baeldung.com/maven-java-version)

I got this to build locally by amending:
- $JAVA_HOME to 11
- `~/.mavenrc` file to 11