### PR TITLE
routes file not required since service is just a consumer

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,5 +1,0 @@
-app_name: officer-delta-processor
-group: internalapi
-weight: 900    
-routes:    
-   1: ^/officer-delta-processor.*

--- a/run_dapperdox.sh
+++ b/run_dapperdox.sh
@@ -1,6 +1,6 @@
 ${DAPPERDOX}/dapperdox \
     -spec-dir=${PWD}/spec/ \
-    -spec-filename=swagger.json \
+    -spec-filename=openapi.json \
     -bind-addr=0.0.0.0:4005 \
     -site-url=http://localhost:4005 \
     -log-level=debug \


### PR DESCRIPTION
This is my understanding from what Billy advised.
`healthCheck` and msgs consumed from chs-delta-api still works in docker

Comparing with other consumer services most don't have a routes.yaml though some do.  I suppose we should add back in later, if we do subsequently require it.

(I've also included a small correction to spec name in dapperdox script)