### PR TITLE
Setup sonar test coverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
@@ -30,6 +31,9 @@
 		<equalsverifier.version>3.1.9</equalsverifier.version>
 		<testcontainers.version>1.15.3</testcontainers.version>
 		<system-lambda.version>1.2.0</system-lambda.version>
+		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
+		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
+		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
 
 		<!-- Spring -->
 		<spring-boot-dependencies.version>2.4.4</spring-boot-dependencies.version>
@@ -40,8 +44,20 @@
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
 
+		<!-- Sonar dependency -->
+		<sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>
+		<sonar.java.coveragePlugin>jacoco</sonar.java.coveragePlugin>
+		<sonar.projectKey>uk.gov.companieshouse:officer-delta-processor</sonar.projectKey>
+		<sonar.sources>src/main</sonar.sources>
+		<sonar.tests>src/test</sonar.tests>
+		<sonar.verbose>true</sonar.verbose>
+		<sonar.coverage.jacoco.xmlReportPaths>
+			${project.basedir}/target/site/jacoco/jacoco.xml,
+			${project.basedir}/target/site/jacoco-it/jacoco.xml
+		</sonar.coverage.jacoco.xmlReportPaths>
+		<sonar.jacoco.reports>${project.basedir}/target/site</sonar.jacoco.reports>
 	</properties>
-		<dependencyManagement>
+	<dependencyManagement>
 		<dependencies>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
@@ -179,9 +195,60 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.1</version>
+				<version>${maven-surefire-plugin.version}</version>
+			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-failsafe-plugin</artifactId>
+				<version>${maven-failsafe-plugin.version}</version>
+				<configuration>
+					<!--suppress UnresolvedMavenProperty -->
+					<argLine>${failsafeArgLine}</argLine>
+					<!--This is a workaround for failsafe not running integration tests-->
+					<!-- https://stackoverflow.com/a/52532095 -->
+					<classesDirectory>${project.build.outputDirectory}</classesDirectory>
+				</configuration>
+				<executions>
+					<execution>
+						<goals>
+							<goal>integration-test</goal>
+							<goal>verify</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.jacoco</groupId>
+				<artifactId>jacoco-maven-plugin</artifactId>
+				<version>${jacoco-maven-plugin.version}</version>
+				<executions>
+					<execution>
+						<id>pre-integration-test</id>
+						<phase>pre-integration-test</phase>
+						<goals>
+							<goal>prepare-agent</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+							<destFile>${sonar.jacoco.reports}/jacoco-it.exec</destFile>
+							<propertyName>failsafeArgLine</propertyName>
+						</configuration>
+					</execution>
+					<execution>
+						<id>post-integration-test</id>
+						<phase>post-integration-test</phase>
+						<goals>
+							<goal>report</goal>
+						</goals>
+						<configuration>
+							<!-- Sets the path to the file which contains the execution data. -->
+							<dataFile>${sonar.jacoco.reports}/jacoco-it.exec</dataFile>
+							<!-- Sets the output directory for the code coverage report. -->
+							<outputDirectory>${sonar.jacoco.reports}/jacoco-it</outputDirectory>
+						</configuration>
+					</execution>
+				</executions>
 			</plugin>
 		</plugins>
 	</build>
-
 </project>

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
@@ -55,7 +55,7 @@ public class DeltaConsumer {
     @Scheduled(
             fixedRateString = "${kafka.polling.duration.ms}",
             initialDelayString = "${kafka.polling.initial.delay.ms}")
-    void pollKafka() {
+    void pollKafka() throws InterruptedException {
         Map<String, Object> pollingInfo = new HashMap<>();
         pollingInfo.put("duration", String.format("%dms", kafkaPollingDuration));
         logger.trace("Polling Kafka", pollingInfo);
@@ -84,7 +84,7 @@ public class DeltaConsumer {
         }
     }
 
-    void sendMessageToRetryTopic(Message message) {
+    void sendMessageToRetryTopic(Message message) throws InterruptedException {
         Map<String, Object> loggingInfo = new HashMap<>();
         loggingInfo.put("key", message.getKey());
         loggingInfo.put("topic", message.getTopic());
@@ -104,9 +104,6 @@ public class DeltaConsumer {
                 logger.info("Message successfully sent to retry topic", loggingInfo);
             } catch (ExecutionException e) {
                 logger.error("Error occurred while send message to retry topic", e, loggingInfo);
-            } catch (InterruptedException e) {
-                logger.error("Interrupted while sending message to retry topic", e, loggingInfo);
-                break;
             }
         }
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
@@ -113,9 +113,9 @@ public class DeltaConsumer {
                 loggingInfo);
     }
 
+    @SuppressWarnings("java:S1186")
+        // Remove once method
     void sendMessageToErrorTopic(Message message) {
-        // Remove once implemented
-        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
@@ -117,7 +117,8 @@ public class DeltaConsumer {
     }
 
     void sendMessageToErrorTopic(Message message) {
-
+        // Remove once implemented
+        throw new UnsupportedOperationException();
     }
 
     /**

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/exception/ProcessException.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/exception/ProcessException.java
@@ -6,7 +6,7 @@ package uk.gov.companieshouse.officer.delta.processor.exception;
  * to the error topic.
  */
 public class ProcessException extends Exception {
-    private boolean canRetry;
+    private final boolean canRetry;
 
     public ProcessException(String message, Throwable cause, boolean canRetry) {
         super(message, cause);
@@ -37,9 +37,5 @@ public class ProcessException extends Exception {
 
     public boolean canRetry() {
         return canRetry;
-    }
-
-    public void setCanRetry(boolean canRetry) {
-        this.canRetry = canRetry;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/Processor.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/Processor.java
@@ -2,6 +2,6 @@ package uk.gov.companieshouse.officer.delta.processor.processor;
 
 import uk.gov.companieshouse.officer.delta.processor.exception.ProcessException;
 
-public interface Processor<InputModel> {
-    void process(InputModel delta) throws ProcessException;
+public interface Processor<I> {
+    void process(I delta) throws ProcessException;
 }

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/KafkaExtension.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/KafkaExtension.java
@@ -1,0 +1,68 @@
+package uk.gov.companieshouse.officer.delta.processor;
+
+import com.github.stefanbirkner.systemlambda.SystemLambda;
+import org.junit.jupiter.api.extension.AfterAllCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
+
+/**
+ * Extension for setting up a kafka container before all of the tests and
+ * destroying it afterward. Since test containers maps the ports to an arbitrary port this extension
+ * exports the kafka port to the kafka.broker.url property and
+ * sets the KAFKA_BROKER_ADDR environment variable.
+ */
+public class KafkaExtension implements BeforeAllCallback, AfterAllCallback {
+    private KafkaContainer kafkaContainer;
+    private SystemLambda.WithEnvironmentVariables env;
+    Map<String, String> originalVariables;
+
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) {
+        kafkaContainer = new KafkaContainer(
+                DockerImageName.parse("confluentinc/cp-kafka"));
+        kafkaContainer.start();
+
+        String kafkaUrl = String.format("localhost:%d", kafkaContainer.getFirstMappedPort());
+        System.setProperty("kafka.broker.url", kafkaUrl);
+        setKafkaEnvironmentVariable(kafkaUrl);
+    }
+
+    /**
+     * System lambda only allows for setting environment variables within a lambda
+     * this doesn't work well with the junit extension life cycle, which doesn't have an
+     * "around" callback. So instead, this method uses Reflection magic to access system
+     * lambdas internal methods for setting and restoring environment variables.
+     *
+     * @param kafkaBrokerAddr the address for the kafka broker
+     */
+    private void setKafkaEnvironmentVariable(final String kafkaBrokerAddr) {
+        originalVariables = new HashMap<>(System.getenv());
+        env = withEnvironmentVariable("KAFKA_BROKER_ADDR", kafkaBrokerAddr);
+        ReflectionTestUtils.invokeMethod(env, "setEnvironmentVariables");
+    }
+
+    /**
+     * System lambda only allows for setting environment variables within a lambda
+     * this doesn't work well with the junit extension life cycle, which doesn't have an
+     * "around" callback. So instead, this method uses Reflection magic to access system
+     * lambdas internal methods for setting and restoring environment variables.
+     */
+    private void restoreOriginalEnvironment() {
+        ReflectionTestUtils.invokeMethod(env, "restoreOriginalVariables", originalVariables);
+    }
+
+
+    @Override
+    public void afterAll(ExtensionContext extensionContext) {
+        restoreOriginalEnvironment();
+        kafkaContainer.stop();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/OfficerDeltaProcessorApplicationTests.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/OfficerDeltaProcessorApplicationTests.java
@@ -13,6 +13,7 @@ import org.springframework.test.context.TestPropertySource;
 class OfficerDeltaProcessorApplicationTests {
 
     @Test
+    @SuppressWarnings("squid:S2699")
     void contextLoads() {
     }
 

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
@@ -70,7 +70,7 @@ class DeltaConsumerTest {
 
     @Test
     @DisplayName("Given no messages on the topic, pollKafka shouldn't do anything")
-    void pollKafkaNoMessages() {
+    void pollKafkaNoMessages() throws InterruptedException {
         // Given
         addKafkaMessages(List.of());
 
@@ -81,7 +81,7 @@ class DeltaConsumerTest {
 
     @Test
     @DisplayName("Given a message is on the topic, pollKafka should pass it to the deserializer and processor")
-    void pollKafka() throws DeserializationException, ProcessException {
+    void pollKafka() throws DeserializationException, ProcessException, InterruptedException {
         // Given
         Message message = new Message();
         addKafkaMessages(List.of(message));
@@ -97,7 +97,7 @@ class DeltaConsumerTest {
 
     @Test
     @DisplayName("Given an exception occurs when deserializing, the message is passed to the error topic")
-    void pollKafkaDeserializeException() throws DeserializationException {
+    void pollKafkaDeserializeException() throws DeserializationException, InterruptedException {
         // Given
         Message message = new Message();
         addKafkaMessages(List.of(message));
@@ -111,7 +111,7 @@ class DeltaConsumerTest {
 
     @Test
     @DisplayName("Given a non-fatal exception occurs when processing, the message is passed to the retry topic")
-    void pollKafkaProcessorNonFatalException() throws DeserializationException, ProcessException {
+    void pollKafkaProcessorNonFatalException() throws DeserializationException, ProcessException, InterruptedException {
         // Given
         Message message = new Message();
         addKafkaMessages(List.of(message));
@@ -126,7 +126,7 @@ class DeltaConsumerTest {
 
     @Test
     @DisplayName("Given a fatal exception occurs when processing, the message is passed to the error topic")
-    void pollKafkaProcessorFatalException() throws DeserializationException, ProcessException {
+    void pollKafkaProcessorFatalException() throws DeserializationException, ProcessException, InterruptedException {
         // Given
         Message message = new Message();
         addKafkaMessages(List.of(message));

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutionException;
 
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.argThat;
@@ -176,17 +177,14 @@ class DeltaConsumerTest {
     }
 
     @Test
-    @DisplayName("Given the consumer is interrupted while trying to send a message to the retry topic, ")
+    @DisplayName("Given the consumer is interrupted while trying to send a message to the retry topic, it is passed to the caller")
     void sendMessageToRetryTopicInterrupt() throws ExecutionException, InterruptedException {
         Message message = new Message();
         doThrow(new InterruptedException(null)).when(chKafkaConsumerGroup).retry(0, message);
 
-        consumer.sendMessageToRetryTopic(message);
-
-        verify(chKafkaConsumerGroup, atLeastOnce()).retry(0, message);
-        verify(chKafkaConsumerGroup, never()).commit(message);
-        verify(logger, atLeastOnce()).error(contains("Interrupted"), any(InterruptedException.class),
-                argThat(hasKey("kafkaMessage")));
+        assertThrows(InterruptedException.class, () -> {
+            consumer.sendMessageToRetryTopic(message);
+        });
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
@@ -190,6 +190,7 @@ class DeltaConsumerTest {
     }
 
     @Test
+    @SuppressWarnings("squid:S2699")
     void sendMessageToErrorTopic() {
 
     }

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/exception/ProcessExceptionTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/exception/ProcessExceptionTest.java
@@ -5,6 +5,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -33,7 +34,7 @@ class ProcessExceptionTest {
     @ValueSource(booleans = {true, false})
     void getterAndSetter(boolean canRetry) {
         ProcessException e = new ProcessException("", null, false);
-        e.setCanRetry(canRetry);
+        ReflectionTestUtils.setField(e, "canRetry", canRetry);
 
         assertEquals(canRetry, e.canRetry());
     }


### PR DESCRIPTION
Sets up sonar test coverage report by producing jacoco report on executed code.
Runs both unit-tests and integration tests.

Additionally, some blocking sonar issues needed to be fixed, and the `OfficerDeltaConsumerIT` test needed to be fixed due to a race condition between the kafka container starting and the test running. This was fixed by using a custom Junit5 extension to ensure the container is started before the test ran. 

Main story: [DSND-128](https://companieshouse.atlassian.net/browse/DSND-128)

Additional sonar stories completed:
- [DSND-130](https://companieshouse.atlassian.net/browse/DSND-130)
- [DSND-131](https://companieshouse.atlassian.net/browse/DSND-131)