### PR TITLE
Fix changed_at date parsing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
@@ -14,10 +14,10 @@ public class TransformerUtils {
 
     public static final String TIME_START_OF_DAY = "000000";
     public static final String DATETIME_PATTERN = "yyyyMMddHHmmss";
+    public static final int DATETIME_LENGTH = DATETIME_PATTERN.length();
     public static final String DATE_PATTERN = "yyyyMMdd";
     public static final DateTimeFormatter UTC_DATETIME_FORMATTER =
             DateTimeFormatter.ofPattern(DATETIME_PATTERN, Locale.UK).withZone(ZoneId.of("UTC"));
-    private static final String SALT = "sdlfksdlkjdf";
 
     private TransformerUtils() {
         // utility class; prevent instantiation
@@ -28,7 +28,7 @@ public class TransformerUtils {
     }
 
     /**
-     * @param identifier
+     * @param identifier       the field identifier to provide context in error messages
      * @param s                the string representation of the UTC datetime. Expected to match pattern
      *                         DATETIME_PATTERN.
      * @param effectivePattern the date pattern to mention in the ProcessException
@@ -71,7 +71,11 @@ public class TransformerUtils {
      */
     public static Instant parseDateTimeString(final String identifier, String rawDateTimeString)
             throws ProcessException {
-        return convertToInstant(identifier, rawDateTimeString, DATETIME_PATTERN);
+        final String dateTimeString = rawDateTimeString.length() > DATETIME_LENGTH
+                ? rawDateTimeString.substring(0, DATETIME_LENGTH)
+                : rawDateTimeString;
+
+        return convertToInstant(identifier, dateTimeString, DATETIME_PATTERN);
     }
 
     public static String base64Encode(final String plain) {


### PR DESCRIPTION
Allow changed_at field to contain fractional seconds. Truncate fractional seconds before converting to Date/Time for storage.