### PR TITLE
Add Residential Address data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<kafka-models.version>1.0.25</kafka-models.version>
 		<structured-logging.version>1.9.3</structured-logging.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
-		<private.sdk.version>2.0.83</private.sdk.version>
+		<private.sdk.version>unversioned</private.sdk.version>
 
 		<!-- Test -->
 		<mockito-junit-jupiter.version>3.8.0</mockito-junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<kafka-models.version>1.0.25</kafka-models.version>
 		<structured-logging.version>1.9.3</structured-logging.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
-		<private.sdk.version>unversioned</private.sdk.version>
+		<private.sdk.version>2.0.88</private.sdk.version>
 
 		<!-- Test -->
 		<mockito-junit-jupiter.version>3.8.0</mockito-junit-jupiter.version>

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItem.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItem.java
@@ -5,13 +5,13 @@ import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.commons.lang3.builder.ReflectionToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import uk.gov.companieshouse.api.model.delta.officers.AddressAPI;
-
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class OfficersItem {
@@ -35,6 +35,9 @@ public class OfficersItem {
 
     @JsonProperty(value = "service_address_same_as_registered_address", required = true)
     private String serviceAddressSameAsRegisteredAddress;
+
+    @JsonProperty(value = "residential_address_same_as_service_address", required = true)
+    private String residentialAddressSameAsServiceAddress;
 
     @JsonProperty(value = "appointment_date", required = true)
     private String appointmentDate;
@@ -91,7 +94,7 @@ public class OfficersItem {
     private String secureDirector;
 
     @JsonProperty("previous_name_array")
-    private PreviousNameArray previousNameArray;
+    private List<PreviousNameArray> previousNameArray;
 
     @JsonIgnore
     private Map<String, Object> additionalProperties = new HashMap<>();
@@ -152,6 +155,15 @@ public class OfficersItem {
 
     public String getServiceAddressSameAsRegisteredAddress() {
         return serviceAddressSameAsRegisteredAddress;
+    }
+
+    public String getResidentialAddressSameAsServiceAddress() {
+        return residentialAddressSameAsServiceAddress;
+    }
+
+    public void setResidentialAddressSameAsServiceAddress(
+        final String residentialAddressSameAsServiceAddress) {
+        this.residentialAddressSameAsServiceAddress = residentialAddressSameAsServiceAddress;
     }
 
     public void setAppointmentDate(String appointmentDate) {
@@ -306,12 +318,12 @@ public class OfficersItem {
         return secureDirector;
     }
 
-    public void setPreviousNameArray(PreviousNameArray previousNameArray) {
-        this.previousNameArray = previousNameArray;
+    public List<PreviousNameArray> getPreviousNameArray() {
+        return previousNameArray;
     }
 
-    public PreviousNameArray getPreviousNameArray() {
-        return previousNameArray;
+    public void setPreviousNameArray(final List<PreviousNameArray> previousNameArray) {
+        this.previousNameArray = previousNameArray;
     }
 
     @Override
@@ -334,6 +346,8 @@ public class OfficersItem {
                 that.getDateOfBirth())
                 && Objects.equals(getServiceAddressSameAsRegisteredAddress(),
                 that.getServiceAddressSameAsRegisteredAddress())
+               && Objects.equals(getResidentialAddressSameAsServiceAddress(),
+            that.getResidentialAddressSameAsServiceAddress())
                 && Objects.equals(getAppointmentDate(),
                 that.getAppointmentDate())
                 && Objects.equals(getResignationDate(), that.getResignationDate())
@@ -366,6 +380,7 @@ public class OfficersItem {
                 getKind(),
                 getDateOfBirth(),
                 getServiceAddressSameAsRegisteredAddress(),
+                getResidentialAddressSameAsServiceAddress(),
                 getAppointmentDate(),
                 getResignationDate(),
                 getOfficerDetailId(),

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -48,6 +48,7 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         officer.setServiceAddressSameAsRegisteredOfficeAddress(
                 parseYesOrNo(source.getServiceAddressSameAsRegisteredAddress()));
         officer.setUsualResidentialAddress(source.getUsualResidentialAddress());
+        officer.setResidentialAddressSameAsServiceAddress(parseYesOrNo(source.getResidentialAddressSameAsServiceAddress()));
         officer.setCountryOfResidence(source.getUsualResidentialCountry());
 
         officer.setIdentificationData(idTransform.transform(source.getIdentification()));

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -47,6 +47,7 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         officer.setServiceAddress(source.getServiceAddress());
         officer.setServiceAddressSameAsRegisteredOfficeAddress(
                 parseYesOrNo(source.getServiceAddressSameAsRegisteredAddress()));
+        officer.setUsualResidentialAddress(source.getUsualResidentialAddress());
         officer.setCountryOfResidence(source.getUsualResidentialCountry());
 
         officer.setIdentificationData(idTransform.transform(source.getIdentification()));

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItemTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItemTest.java
@@ -7,6 +7,8 @@ import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 
+import java.util.ArrayList;
+import java.util.List;
 import nl.jqno.equalsverifier.EqualsVerifier;
 import nl.jqno.equalsverifier.Warning;
 import org.junit.jupiter.api.BeforeEach;
@@ -188,7 +190,7 @@ class OfficersItemTest {
 
     @Test
     void setPreviousNameArray() {
-        final PreviousNameArray expected = new PreviousNameArray();
+        final List<PreviousNameArray> expected = new ArrayList<PreviousNameArray>();
 
         testItem.setPreviousNameArray(expected);
         assertThat(testItem.getPreviousNameArray(), is(sameInstance(expected)));

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItemTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItemTest.java
@@ -72,6 +72,12 @@ class OfficersItemTest {
     }
 
     @Test
+    void setResidentialAddressSameAsServiceAddress() {
+        testItem.setResidentialAddressSameAsServiceAddress(EXPECTED);
+        assertThat(testItem.getResidentialAddressSameAsServiceAddress(), is(EXPECTED));
+    }
+
+    @Test
     void setAppointmentDate() {
         testItem.setAppointmentDate(EXPECTED);
         assertThat(testItem.getAppointmentDate(), is(EXPECTED));

--- a/src/test/resources/officer_delta_example.json
+++ b/src/test/resources/officer_delta_example.json
@@ -20,11 +20,11 @@
       "officer_detail_id": "3456251385",
       "officer_role": "Director",
       "usual_residential_country": "United Kingdom",
-      "previous_name_array": {
+      "previous_name_array": [{
         "previous_surname": "BURCH",
         "previous_forename": "VALERIE JEAN",
         "previous_timestamp": "20091101072217613702"
-      },
+      }],
       "identification": {
         "EEA": {
           "place_registered": "United Kingdom",


### PR DESCRIPTION
Allows this to pass through the processor:
```
"usual_residential_address": {
        "premise": "URA",
        "address_line_1": "ura_line1",
        ...      
      },
"residential_address_same_as_service_address": "Y",
"previous_name_array": [{
        "previous_surname": "BURCH",
         ...
      }],
```

Associated `private-sdk` PR: https://github.com/companieshouse/private-api-sdk-java/pull/116
Associated `company-appointments.api` PR: https://github.com/companieshouse/company-appointments.api.ch.gov.uk/pull/22

chs-delta-api change done for URA same as Service Address indicator - https://github.com/companieshouse/chs-delta-api/pull/49/files
note this also amend the previous_name_array structure

DSND-183