### PR TITLE
Add the RolesWithOccupation business rule

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithOccupation.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithOccupation.java
@@ -32,8 +32,3 @@ public enum RolesWithOccupation {
             .anyMatch(role::equals);
     }
 }
-
-
-
-
-

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithOccupation.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithOccupation.java
@@ -1,0 +1,39 @@
+package uk.gov.companieshouse.officer.delta.processor.model.enums;
+
+import java.util.EnumSet;
+
+public enum RolesWithOccupation {
+
+    DIRECTOR(OfficerRole.DIR),
+    MEMBER_OF_A_MANAGEMENT_ORGAN(OfficerRole.MEMMANORG),
+    MEMBER_OF_A_SUPERVISORY_ORGAN(OfficerRole.MEMSUPORG),
+    MEMBER_OF_AN_ADMINISTRATIVE_ORGAN(OfficerRole.MEMADMORG),
+    NOMINEE_DIRECTOR(OfficerRole.NOMDIR),
+    NOMINEE_SECRETARY(OfficerRole.NOMSEC),
+    SECRETARY(OfficerRole.SEC);
+
+    private final OfficerRole officerRole;
+
+    RolesWithOccupation(OfficerRole officerRole) {
+        this.officerRole = officerRole;
+    }
+
+    public String getOfficerRole() {
+        return officerRole.getValue();
+    }
+
+    public static boolean includes(final OfficerRole role) {
+        return includes(role.getValue());
+    }
+
+    public static boolean includes(final String role) {
+        return EnumSet.allOf(RolesWithOccupation.class).stream()
+            .map(r -> r.officerRole.getValue())
+            .anyMatch(role::equals);
+    }
+}
+
+
+
+
+

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -7,6 +7,7 @@ import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
 import uk.gov.companieshouse.officer.delta.processor.exception.ProcessException;
 import uk.gov.companieshouse.officer.delta.processor.model.OfficersItem;
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithDateOfBirth;
+import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithOccupation;
 
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseDateString;
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseDateTimeString;
@@ -42,12 +43,15 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         officer.setForename(source.getForename());
         officer.setOtherForenames(source.getMiddleName());
         officer.setSurname(source.getSurname());
-        officer.setNationality(source.getNationality());
-        officer.setOccupation(source.getOccupation());
-
 
         final String officerRole = TransformerUtils.lookupOfficeRole(source.getKind());
         officer.setOfficerRole(officerRole);
+
+        // Occupation and Nationality are in the same set of Roles
+        if (RolesWithOccupation.includes(officerRole)) {
+            officer.setNationality(source.getNationality());
+            officer.setOccupation(source.getOccupation());
+        }
         officer.setHonours(source.getHonours());
 
         officer.setServiceAddress(source.getServiceAddress());

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
@@ -21,6 +21,7 @@ import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithDateOf
 
 import java.time.Instant;
 import java.util.stream.Stream;
+import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithOccupation;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
@@ -128,6 +129,30 @@ class OfficerTransformTest {
             assertThat(outputOfficer.getDateOfBirth(), is(notNullValue()));
         } else {
             assertThat(outputOfficer.getDateOfBirth(), is(nullValue()));
+        }
+    }
+
+    @DisplayName("Occupation and Nationality is not included when the officers role does not require it")
+    @ParameterizedTest
+    @EnumSource
+    void onlyRolesWithOccupationIncludeOccupationAndNationality(OfficerRole officerRole) throws ProcessException {
+        final OfficersItem officer = createOfficer(addressAPI, identification);
+
+        officer.setDateOfBirth(VALID_DATE);
+        officer.setKind(officerRole.name());
+        officer.setChangedAt(CHANGED_AT);
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setOccupation("Super Hero");
+        officer.setNationality("Krypton");
+
+        final OfficerAPI outputOfficer = testTransform.transform(officer);
+
+        if (RolesWithOccupation.includes(officerRole)) {
+            assertThat(outputOfficer.getOccupation(), is(notNullValue()));
+            assertThat(outputOfficer.getNationality(), is(notNullValue()));
+        } else {
+            assertThat(outputOfficer.getOccupation(), is(nullValue()));
+            assertThat(outputOfficer.getNationality(), is(nullValue()));
         }
     }
 


### PR DESCRIPTION
Replicates these lines in Transform we're replacing - https://github.com/companieshouse/chs-transform-api/blob/master/lib/ChsTransformApi/Transforms/Mapping/Officer/Natural.pm#L66-L69

Note Occupation and Nationality have been grouped together and I've commented to that effect.

DSND-180