### PR TITLE
Implement Roles with Residential addresses

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<kafka-models.version>1.0.25</kafka-models.version>
 		<structured-logging.version>1.9.3</structured-logging.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
-		<private.sdk.version>unversioned</private.sdk.version>
+		<private.sdk.version>2.0.92</private.sdk.version>
 
 		<!-- Test -->
 		<mockito-junit-jupiter.version>3.8.0</mockito-junit-jupiter.version>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
 		<kafka-models.version>1.0.25</kafka-models.version>
 		<structured-logging.version>1.9.3</structured-logging.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
-		<private.sdk.version>2.0.90</private.sdk.version>
+		<private.sdk.version>unversioned</private.sdk.version>
 
 		<!-- Test -->
 		<mockito-junit-jupiter.version>3.8.0</mockito-junit-jupiter.version>

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithResidentialAddress.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithResidentialAddress.java
@@ -1,0 +1,36 @@
+package uk.gov.companieshouse.officer.delta.processor.model.enums;
+
+import java.util.EnumSet;
+
+public enum RolesWithResidentialAddress {
+
+    DIRECTOR(OfficerRole.DIR),
+    LLPMEM(OfficerRole.LLPMEM),
+    LLPDESMEM(OfficerRole.LLPDESMEM),
+    MEMBER_OF_A_MANAGEMENT_ORGAN(OfficerRole.MEMMANORG),
+    MEMBER_OF_A_SUPERVISORY_ORGAN(OfficerRole.MEMSUPORG),
+    MEMBER_OF_AN_ADMINISTRATIVE_ORGAN(OfficerRole.MEMADMORG),
+    NOMINEE_DIRECTOR(OfficerRole.NOMDIR),
+    PERSAUTHR(OfficerRole.PERSAUTHR),
+    PERSAUTHRA(OfficerRole.PERSAUTHRA);
+
+    private final OfficerRole officerRole;
+
+    RolesWithResidentialAddress(OfficerRole officerRole) {
+        this.officerRole = officerRole;
+    }
+
+    public String getOfficerRole() {
+        return officerRole.getValue();
+    }
+
+    public static boolean includes(final OfficerRole role) {
+        return includes(role.getValue());
+    }
+
+    public static boolean includes(final String role) {
+        return EnumSet.allOf(RolesWithResidentialAddress.class).stream()
+            .map(r -> r.officerRole.getValue())
+            .anyMatch(role::equals);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -1,6 +1,7 @@
 package uk.gov.companieshouse.officer.delta.processor.tranformer;
 
 
+import org.apache.commons.lang.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
@@ -10,6 +11,7 @@ import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithCountr
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithPre1992Appointment;
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithDateOfBirth;
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithOccupation;
+import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithResidentialAddress;
 
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseDateString;
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseDateTimeString;
@@ -78,9 +80,13 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         officer.setServiceAddress(source.getServiceAddress());
         officer.setServiceAddressSameAsRegisteredOfficeAddress(
                 parseYesOrNo(source.getServiceAddressSameAsRegisteredAddress()));
-        officer.setUsualResidentialAddress(source.getUsualResidentialAddress());
-        officer.setResidentialAddressSameAsServiceAddress(
-                parseYesOrNo(source.getResidentialAddressSameAsServiceAddress()));
+
+        if (RolesWithResidentialAddress.includes(officerRole)) {
+            officer.setUsualResidentialAddress(source.getUsualResidentialAddress());
+            officer.setResidentialAddressSameAsServiceAddress(
+                BooleanUtils.toBooleanObject(source.getResidentialAddressSameAsServiceAddress()));
+            officer.setSecureOfficer(BooleanUtils.toBooleanObject(source.getSecureDirector()));
+        }
 
         if (RolesWithCountryOfResidence.includes(officerRole)) {
             officer.setCountryOfResidence(source.getUsualResidentialCountry());

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
@@ -27,8 +27,8 @@ public class TransformerUtils {
         // utility class; prevent instantiation
     }
 
-    public static boolean parseYesOrNo(final String serviceAddressSameAsRegisteredAddress) {
-        return "Y".equalsIgnoreCase(serviceAddressSameAsRegisteredAddress);
+    public static boolean parseYesOrNo(final String fieldValue) {
+        return "Y".equalsIgnoreCase(fieldValue);
     }
 
     /**


### PR DESCRIPTION
Capture the residential address, residentialAddressSameAsServiceAddress and Secure officer indicator only when officer role requires it

Associated PR's:
comp-app https://github.com/companieshouse/company-appointments.api.ch.gov.uk/pull/23
private sdk https://github.com/companieshouse/private-api-sdk-java/pull/119

DSND-181