### PR TITLE
Fix NullPointerException when 'identification' section missing

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -16,10 +16,11 @@ import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithCountr
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithDateOfBirth;
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithFormerNames;
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithOccupation;
-import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithResidentialAddress;
 import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithPre1992Appointment;
+import uk.gov.companieshouse.officer.delta.processor.model.enums.RolesWithResidentialAddress;
 
 import java.time.Instant;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -92,7 +93,7 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         if (RolesWithResidentialAddress.includes(officerRole)) {
             officer.setUsualResidentialAddress(source.getUsualResidentialAddress());
             officer.setResidentialAddressSameAsServiceAddress(
-                BooleanUtils.toBooleanObject(source.getResidentialAddressSameAsServiceAddress()));
+                    BooleanUtils.toBooleanObject(source.getResidentialAddressSameAsServiceAddress()));
             officer.setSecureOfficer(BooleanUtils.toBooleanObject(source.getSecureDirector()));
         }
 
@@ -100,7 +101,8 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
             officer.setCountryOfResidence(source.getServiceAddress().getUsualCountryOfResidence());
         }
 
-        officer.setIdentificationData(idTransform.transform(source.getIdentification()));
+        Optional.ofNullable(source.getIdentification())
+                .ifPresent(i -> officer.setIdentificationData(idTransform.transform(i)));
 
         if (RolesWithDateOfBirth.includes(officerRole) && isNotEmpty(source.getDateOfBirth())) {
             officer.setDateOfBirth(parseDateString("dateOfBirth", source.getDateOfBirth()));

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
@@ -6,7 +6,10 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.CoreMatchers.sameInstance;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.isA;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.DATETIME_LENGTH;
 
@@ -112,13 +115,27 @@ class OfficerTransformTest {
         verifyProcessingError(officerAPI, officer, "appointmentDate: date/time pattern not matched: [yyyyMMdd]");
     }
 
+    @DisplayName("Identification (optional) is not transformed if not present")
+    @Test
+    void transformIdentificationWhenNotPresent() {
+        final OfficersItem officer = createOfficer(addressAPI, null);
+
+        officer.setChangedAt(CHANGED_AT);
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+
+        testTransform.transform(officer);
+
+        verifyNoInteractions(identificationTransform);
+    }
+
     @Test
     void transformSingleWhenResignationDateInvalid() {
         final OfficerAPI officerAPI = testTransform.factory();
         final OfficersItem officer = createOfficer(addressAPI, identification);
 
         officer.setChangedAt(CHANGED_AT);
-        officer.setAppointmentDate("20000101");
+        officer.setAppointmentDate(VALID_DATE);
         officer.setResignationDate(INVALID_DATE);
 
         verifyProcessingError(officerAPI, officer, "resignation_date: date/time pattern not matched: [yyyyMMdd]");


### PR DESCRIPTION
- transform the identification section only if present
