### PR TITLE
Enable healthcheck

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,0 +1,5 @@
+app_name: officer-delta-processor
+group: internalapi
+weight: 900
+routes:
+   1: ^/officer-delta-processor.*


### PR DESCRIPTION
Enables healthcheck by restoring `routes.yaml` file which was previously deleted. This allows healthcheck requests to be sent to the `/officer-delta-processor/healthCheck` endpoint.