### PR TITLE
Fix log4j vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
 		<structured-logging.version>1.9.10</structured-logging.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
 		<private.sdk.version>2.0.98</private.sdk.version>
+		<log4j-bom.version>2.16.0</log4j-bom.version>
 
 		<!-- Test -->
 		<mockito-junit-jupiter.version>3.8.0</mockito-junit-jupiter.version>
@@ -60,6 +61,15 @@
 	</properties>
 	<dependencyManagement>
 		<dependencies>
+			<!-- Fix for CVE-2021-44228 -->
+			<!-- Required until v2.5.8 springframework & v2.6.2 springboot -->
+			<dependency>
+				<groupId>org.apache.logging.log4j</groupId>
+				<artifactId>log4j-bom</artifactId>
+				<version>${log4j-bom.version}</version>
+				<scope>import</scope>
+				<type>pom</type>
+			</dependency>
 			<dependency>
 				<groupId>org.springframework.boot</groupId>
 				<artifactId>spring-boot-dependencies</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
 		<avro.version>1.8.1</avro.version>
 		<ch-kafka.version>1.4.4</ch-kafka.version>
 		<kafka-models.version>1.0.25</kafka-models.version>
-		<structured-logging.version>1.9.3</structured-logging.version>
+		<structured-logging.version>1.9.10</structured-logging.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
 		<private.sdk.version>2.0.98</private.sdk.version>
 


### PR DESCRIPTION
Upgrades log4j-core version to 2.16.0.

```
> mvn dependency:tree | grep log4j

[INFO] |  |  |  +- org.apache.logging.log4j:log4j-to-slf4j:jar:2.16.0:compile
[INFO] |  +- org.apache.logging.log4j:log4j-core:jar:2.16.0:compile
[INFO] |  |  \- org.apache.logging.log4j:log4j-api:jar:2.16.0:compile
```

Resolves: [DEBT-1459](https://companieshouse.atlassian.net/browse/DEBT-1459)