### PR TITLE
Add integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,9 +13,12 @@ clean:
 test-unit: clean
 	mvn test -Dskip.integration.tests=true
 
+.PHONY: test
+test: test-integration test-unit
+
 .PHONY: test-integration
-test-integration: clean
-	mvn integration-test -Dskip.unit.tests=true
+test-integration:
+	mvn integration-test -Dskip.unit.tests=true failsafe:verify
 
 .PHONY: verify
 verify: test-unit test-integration

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,11 @@
 		<maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
 		<maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
 		<jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+		<io-cucumber.version>7.2.3</io-cucumber.version>
+		<skip.integration.tests>false</skip.integration.tests>
+		<skip.unit.tests>false</skip.unit.tests>
+		<assertj-core.version>3.22.0</assertj-core.version>
+		<wiremock.standalone.version>2.32.0</wiremock.standalone.version>
 
 		<!-- Spring -->
 		<spring-boot-dependencies.version>2.6.4</spring-boot-dependencies.version>
@@ -200,6 +205,59 @@
 			<artifactId>system-lambda</artifactId>
 			<version>${system-lambda.version}</version>
 			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-core</artifactId>
+			<version>${io-cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-java</artifactId>
+			<version>${io-cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-junit</artifactId>
+			<version>${io-cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.cucumber</groupId>
+			<artifactId>cucumber-spring</artifactId>
+			<version>${io-cucumber.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.springframework.kafka</groupId>
+			<artifactId>spring-kafka-test</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
+			<version>${wiremock.standalone.version}</version>
+			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>org.conscrypt</groupId>
+					<artifactId>conscrypt-openjdk-uber</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>net.javacrumbs.json-unit</groupId>
+					<artifactId>json-unit-core</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.github.jknack</groupId>
+					<artifactId>handlebars</artifactId>
+				</exclusion>
+				<exclusion>
+					<groupId>com.github.jknack</groupId>
+					<artifactId>handlebars-helpers</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 	</dependencies>
 

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/AbstractIntegrationTest.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/AbstractIntegrationTest.java
@@ -1,0 +1,15 @@
+package uk.gov.companieshouse.officer.delta.processor;
+
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.companieshouse.officer.delta.processor.config.KafkaTestContainerConfig;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@DirtiesContext
+@Import(KafkaTestContainerConfig.class)
+@ActiveProfiles({"test"})
+public abstract class AbstractIntegrationTest {
+
+}

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/CucumberFeaturesRunnerITest.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/CucumberFeaturesRunnerITest.java
@@ -1,0 +1,16 @@
+package uk.gov.companieshouse.officer.delta.processor;
+
+import io.cucumber.junit.Cucumber;
+import io.cucumber.junit.CucumberOptions;
+import io.cucumber.spring.CucumberContextConfiguration;
+import org.junit.runner.RunWith;
+import org.springframework.test.context.TestPropertySource;
+
+@RunWith(Cucumber.class)
+@CucumberOptions(features = "src/itest/resources/features",
+        plugin = {"pretty", "json:target/cucumber-report.json"})
+@CucumberContextConfiguration
+@TestPropertySource(locations="classpath:test.properties")
+public class CucumberFeaturesRunnerITest extends AbstractIntegrationTest {
+
+}

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/config/KafkaTestContainerConfig.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/config/KafkaTestContainerConfig.java
@@ -1,0 +1,113 @@
+package uk.gov.companieshouse.officer.delta.processor.config;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.*;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.officer.delta.processor.exception.RetryableTopicErrorInterceptor;
+import uk.gov.companieshouse.officer.delta.processor.serialization.ChsDeltaDeserializer;
+import uk.gov.companieshouse.officer.delta.processor.serialization.ChsDeltaSerializer;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@TestConfiguration
+public class KafkaTestContainerConfig {
+
+    private final ChsDeltaDeserializer chsDeltaDeserializer;
+    private final ChsDeltaSerializer chsDeltaSerializer;
+
+    @Autowired
+    public KafkaTestContainerConfig(ChsDeltaDeserializer chsDeltaDeserializer, ChsDeltaSerializer chsDeltaSerializer) {
+        this.chsDeltaDeserializer = chsDeltaDeserializer;
+        this.chsDeltaSerializer = chsDeltaSerializer;
+    }
+
+    @Bean
+    public KafkaContainer kafkaContainer() {
+        KafkaContainer kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:latest"));
+        kafkaContainer.start();
+        return kafkaContainer;
+    }
+
+    @Bean
+    ConcurrentKafkaListenerContainerFactory<String, ChsDelta> listenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, ChsDelta> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(kafkaConsumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.RECORD);
+        return factory;
+    }
+
+    @Bean
+    public ConsumerFactory<String, ChsDelta> kafkaConsumerFactory() {
+        return new DefaultKafkaConsumerFactory<>(consumerConfigs(kafkaContainer()),
+                new StringDeserializer(),
+                new ErrorHandlingDeserializer<>(chsDeltaDeserializer));
+    }
+
+    @Bean
+    public Map<String, Object> consumerConfigs(KafkaContainer kafkaContainer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, ChsDeltaDeserializer.class);
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        return props;
+    }
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory(KafkaContainer kafkaContainer) {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ChsDeltaSerializer.class);
+        props.put(ProducerConfig.INTERCEPTOR_CLASSES_CONFIG,
+                RetryableTopicErrorInterceptor.class.getName());
+        DefaultKafkaProducerFactory<String, Object> factory = new DefaultKafkaProducerFactory<>(
+                props, new StringSerializer(), chsDeltaSerializer);
+
+        return factory;
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate() {
+        return new KafkaTemplate<>(producerFactory(kafkaContainer()));
+    }
+
+    @Bean
+    public KafkaConsumer<String, Object> invalidTopicConsumer() {
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer().getBootstrapServers());
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "officer-delta-processor");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        props.put(ErrorHandlingDeserializer.KEY_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, "false");
+        props.put(ConsumerConfig.ISOLATION_LEVEL_CONFIG, "read_committed");
+        KafkaConsumer<String, Object> consumer = new KafkaConsumer<>(props);
+        consumer.subscribe(List.of("officer-delta-invalid",
+                "officer-delta-error", "officer-delta-retry"));
+
+        return consumer;
+    }
+
+}

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/consumer/OfficerDeltaProcessorITest.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/consumer/OfficerDeltaProcessorITest.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.officer.delta.processor.consumer;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.officer.delta.processor.AbstractIntegrationTest;
+
+public class OfficerDeltaProcessorITest extends AbstractIntegrationTest {
+
+    @Autowired
+    public KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Value("${officer.delta.processor.topic}")
+    private String mainTopic;
+
+    @Test
+    public void testSendingKafkaMessage() {
+        ChsDelta chsDelta = new ChsDelta("{ \"key\": \"value\" }", 1, "some_id");
+        kafkaTemplate.send(mainTopic, chsDelta);
+    }
+
+}

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/data/TestData.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/data/TestData.java
@@ -1,0 +1,31 @@
+package uk.gov.companieshouse.officer.delta.processor.data;
+
+import org.springframework.util.FileCopyUtils;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class TestData {
+
+    public static String getInputData(String officerType) {
+        String path = "src/itest/resources/data/" + officerType + "_officer_delta_in.json";
+        return readFile(path);
+    }
+
+    public static String getOutputData(String officerType) {
+        String path = "src/itest/resources/data/" + officerType + "_officer_delta_out.json";
+        return readFile(path).replaceAll("\n", "");
+    }
+
+    private static String readFile(String path) {
+        String data;
+        try {
+            data = FileCopyUtils.copyToString(new InputStreamReader(new FileInputStream(new File(path))));
+        } catch (IOException e) {
+            data = null;
+        }
+        return data;
+    }
+}

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/matcher/OfficerRequestMatcher.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/matcher/OfficerRequestMatcher.java
@@ -1,0 +1,89 @@
+package uk.gov.companieshouse.officer.delta.processor.matcher;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.tomakehurst.wiremock.http.Request;
+import com.github.tomakehurst.wiremock.http.RequestMethod;
+import com.github.tomakehurst.wiremock.matching.MatchResult;
+import com.github.tomakehurst.wiremock.matching.ValueMatcher;
+import uk.gov.companieshouse.logging.Logger;
+
+/**
+ *  Custom matcher class used to match requests made by the consumer to the
+ *  data api. The url, request type and request body are compared.
+ */
+public class OfficerRequestMatcher implements ValueMatcher<Request> {
+
+    private String expectedOutput;
+    private String conumb;
+    private Logger logger;
+
+    public OfficerRequestMatcher(Logger logger, String conumb, String output) {
+        this.conumb = conumb;
+        this.expectedOutput = output;
+        this.logger = logger;
+    }
+
+    @Override
+    public MatchResult match(Request value) {
+
+        return MatchResult.aggregate(matchUrl(value.getUrl()), matchMethod(value.getMethod()),
+                matchBody(value.getBodyAsString()));
+    }
+
+    private MatchResult matchUrl(String actualUrl) {
+        String expectedUrl = "/company/" + conumb + "/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4/full_record";
+
+        MatchResult urlResult = MatchResult.of(expectedUrl.equals(actualUrl));
+
+        if (! urlResult.isExactMatch()) {
+            logger.error("url does not match expected: <" + expectedUrl + "> actual: <" + actualUrl + ">");
+        }
+
+        return urlResult;
+    }
+
+    private MatchResult matchMethod(RequestMethod actualMethod) {
+        RequestMethod expectedMethod = RequestMethod.PUT;
+
+        MatchResult typeResult = MatchResult.of(expectedMethod.equals(actualMethod));
+
+        if (! typeResult.isExactMatch()) {
+            logger.error("Method does not match expected: <" + expectedMethod + "> actual: <" + actualMethod + ">");
+        }
+
+        return typeResult;
+    }
+
+    private MatchResult matchBody(String actualBody) {
+
+        ObjectMapper mapper = new ObjectMapper();
+
+        MatchResult bodyResult;
+        JsonNode expectedBody;
+        try {
+            expectedBody = mapper.readTree(expectedOutput);
+        } catch (JsonProcessingException e) {
+            logger.error("Could not process expectedBody JSON: " + e);
+            return MatchResult.of(false);
+        }
+
+        JsonNode actual;
+        try {
+            actual = mapper.readTree(actualBody);
+        } catch (JsonProcessingException e) {
+            logger.error("Could not process actualBody JSON: " + e);
+            return MatchResult.of(false);
+        }
+
+        bodyResult = MatchResult.of(expectedBody.equals(actual));
+
+        if (! bodyResult.isExactMatch()) {
+            logger.error("Body does not match expected: <" + expectedBody + "> actual: <" + actualBody + ">");
+        }
+
+        return bodyResult;
+    }
+}
+

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/steps/CommonSteps.java
@@ -1,0 +1,152 @@
+package uk.gov.companieshouse.officer.delta.processor.steps;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import io.cucumber.java.After;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import uk.gov.companieshouse.delta.ChsDelta;
+import uk.gov.companieshouse.officer.delta.processor.data.TestData;
+import uk.gov.companieshouse.officer.delta.processor.matcher.OfficerRequestMatcher;
+import uk.gov.companieshouse.logging.Logger;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.StreamSupport;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CommonSteps {
+
+    @Value("${officer.delta.processor.topic}")
+    private String mainTopic;
+
+    @Value("${wiremock.server.port:8888}")
+    private String port;
+
+    private static WireMockServer wireMockServer;
+
+    @Autowired
+    private KafkaTemplate<String, Object> kafkaTemplate;
+    @Autowired
+    public KafkaConsumer<String, Object> kafkaConsumer;
+    @Autowired
+    private Logger logger;
+
+    private String type;
+    private String output;
+
+    @Given("the application is running")
+    public void theApplicationRunning() {
+        assertThat(kafkaTemplate).isNotNull();
+    }
+
+    @When("^the consumer receives a (.*) officer delta$")
+    public void theConsumerReceivesOfficerDelta(String type) throws Exception {
+        configureWiremock();
+        stubPutAppointment("01777777");
+        this.output = TestData.getOutputData(type);
+        this.type = type;
+
+        ChsDelta delta = new ChsDelta(TestData.getInputData(type), 1, "1");
+        kafkaTemplate.send(mainTopic, delta);
+
+        countDown();
+    }
+
+    @When("an invalid avro message is sent")
+    public void invalidAvroMessageIsSent() throws Exception {
+        kafkaTemplate.send(mainTopic, "InvalidData");
+
+        countDown();
+    }
+
+    @When("a message with invalid data is sent")
+    public void messageWithInvalidDataIsSent() throws Exception {
+        ChsDelta delta = new ChsDelta("InvalidData", 1, "1");
+        kafkaTemplate.send(mainTopic, delta);
+
+        countDown();
+    }
+
+    @When("^the consumer receives a message but the data api returns a (\\d*)$")
+    public void theConsumerReceivesMessageButDataApiReturns(int responseCode) throws Exception{
+        configureWiremock();
+        stubPutAppointment("01777777", responseCode);
+
+        ChsDelta delta = new ChsDelta(
+                TestData.getInputData("natural"), 1, "1");
+        kafkaTemplate.send(mainTopic, delta);
+
+        countDown();
+    }
+
+    @When("the consumer receives a message that causes an error")
+    public void theConsumerReceivesMessageThatCausesAnError() throws Exception {
+        ChsDelta delta = new ChsDelta(
+                TestData.getInputData("error"), 1, "1");
+        kafkaTemplate.send(mainTopic, delta);
+
+        countDown();
+    }
+
+    @Then("a PUT request is sent to the appointments api with the transformed data")
+    public void putRequestIsSentToTheAppointmentsApi() {
+        verify(1, requestMadeFor(new OfficerRequestMatcher(logger, "01777777", output)));
+    }
+
+    @Then("^the message should be moved to topic (.*)$")
+    public void theMessageShouldBeMovedToTopic(String topic) {
+        ConsumerRecord<String, Object> singleRecord = KafkaTestUtils.getSingleRecord(kafkaConsumer, topic);
+
+        assertThat(singleRecord.value()).isNotNull();
+    }
+
+    @Then("^the message should retry (\\d*) times and then error$")
+    public void theMessageShouldRetryAndError(int retries) {
+        ConsumerRecords<String, Object> records = KafkaTestUtils.getRecords(kafkaConsumer);
+        Iterable<ConsumerRecord<String, Object>> retryRecords =  records.records("officer-delta-retry");
+        Iterable<ConsumerRecord<String, Object>> errorRecords =  records.records("officer-delta-error");
+
+        int actualRetries = (int) StreamSupport.stream(retryRecords.spliterator(), false).count();
+        int errors = (int) StreamSupport.stream(errorRecords.spliterator(), false).count();
+
+        assertThat(actualRetries).isEqualTo(retries);
+        assertThat(errors).isEqualTo(1);
+    }
+
+    @After
+    public void shutdownWiremock(){
+        if (wireMockServer != null)
+            wireMockServer.stop();
+    }
+
+    private void configureWiremock() {
+        wireMockServer = new WireMockServer(Integer.parseInt(port));
+        wireMockServer.start();
+        configureFor("localhost", Integer.parseInt(port));
+    }
+
+    private void stubPutAppointment(String conumb) {
+        stubPutAppointment(conumb, 200);
+    }
+
+    private void stubPutAppointment(String conumb, int responseCode) {
+        stubFor(put(urlEqualTo("/company/" + conumb + "/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4/full_record"))
+                .willReturn(aResponse().withStatus(responseCode)));
+    }
+
+    private void countDown() throws Exception {
+        CountDownLatch countDownLatch = new CountDownLatch(1);
+        countDownLatch.await(5, TimeUnit.SECONDS);
+    }
+}
+

--- a/src/itest/resources/data/corporate_officer_delta_in.json
+++ b/src/itest/resources/data/corporate_officer_delta_in.json
@@ -1,0 +1,49 @@
+{
+  "officers": [
+    {
+      "company_number": "01777777",
+      "changed_at": "20170605123030",
+      "kind": "DIRCORP",
+      "internal_id": "0025987375",
+      "appointment_date": "20111103",
+      "corporate_ind": "Y",
+      "surname": "MY BIG OLD COMPANY LIMITED",
+      "service_address_same_as_registered_address": "Y",
+      "officer_id": "3001237435",
+      "secure_director": "N",
+      "officer_detail_id": "3456251385",
+      "identification": {
+        "EEA": {
+          "place_registered": "United Kingdom",
+          "registration_number": "38298",
+          "legal_authority": "Chapter 32",
+          "legal_form": "Hong Kong"
+        }
+      },
+      "service_address": {
+        "premise": "1",
+        "address_line_1" : "1 Crown Way",
+        "address_line_2" : "Pavement",
+        "locality" : "Cardiff",
+        "region" : "Cardiff",
+        "postal_code" : "CF14 3UZ",
+        "country": "United Kingdom"
+      },
+      "usual_residential_address": {
+        "premise": "URA",
+        "address_line_1": "ura_line1",
+        "address_line_2": "ura_line2",
+        "locality": "Cardiff",
+        "care_of": "ura_care_of",
+        "region": "ura_region",
+        "po_box": "ura_po",
+        "supplied_company_name": "ura_cname",
+        "country": "United Kingdom",
+        "postal_code": "CF2 1B6",
+        "usual_country_of_residence": "United Kingdom"
+      }
+    }
+  ],
+  "CreatedTime": "07-JUN-21 15.26.17.000000",
+  "delta_at": "20140925171003950844"
+}

--- a/src/itest/resources/data/corporate_officer_delta_out.json
+++ b/src/itest/resources/data/corporate_officer_delta_out.json
@@ -1,0 +1,59 @@
+{
+  "id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "data":{
+    "pre1992Appointment":false,
+    "identificationData":{
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "linksData":{
+      "officer":{
+        "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "service_address":{
+      "address_line_1":"1 Crown Way",
+      "address_line_2":"Pavement",
+      "country":"United Kingdom",
+      "locality":"Cardiff",
+      "postal_code":"CF14 3UZ",
+      "premises":"1",
+      "region":"Cardiff"
+    },
+    "service_address_is_same_as_registered_office_address":true,
+    "appointed_on":1320278400.000000000,
+    "is_pre_1992_appointment":false,
+    "links":{
+      "officer":{
+        "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "officer_role":"corporate-director",
+    "identification":{
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "surname":"MY BIG OLD COMPANY LIMITED",
+    "company_number":"01777777",
+    "updated_at":1496665830.000000000
+  },
+  "sensitive_data":{
+
+  },
+  "internal_id":"0025987375",
+  "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",
+  "previous_officer_id":"vuIAhYYbRDhqzx9b3e_jd6Uhres",
+  "company_number":"01777777",
+  "delta_at":"20140925171003950844"
+}

--- a/src/itest/resources/data/natural_officer_delta_in.json
+++ b/src/itest/resources/data/natural_officer_delta_in.json
@@ -1,0 +1,55 @@
+{
+  "officers": [
+    {
+      "company_number": "01777777",
+      "changed_at": "20170605123030",
+      "kind": "DIR",
+      "internal_id": "0025987375",
+      "appointment_date": "20111103",
+      "title": "Mr",
+      "corporate_ind": "N",
+      "surname": "GLOVER",
+      "forename": "PHIL",
+      "middle_name": "Peter",
+      "date_of_birth": "19850630",
+      "service_address_same_as_registered_address": "Y",
+      "nationality": "British",
+      "occupation": "Lawyer",
+      "officer_id": "3001237435",
+      "secure_director": "N",
+      "officer_detail_id": "3456251385",
+      "identification": {
+        "EEA": {
+          "place_registered": "United Kingdom",
+          "registration_number": "38298",
+          "legal_authority": "Chapter 32",
+          "legal_form": "Hong Kong"
+        }
+      },
+      "service_address": {
+        "premise": "1",
+        "address_line_1" : "1 Crown Way",
+        "address_line_2" : "Pavement",
+        "locality" : "Cardiff",
+        "region" : "Cardiff",
+        "postal_code" : "CF14 3UZ",
+        "country": "United Kingdom"
+      },
+      "usual_residential_address": {
+        "premise": "URA",
+        "address_line_1": "ura_line1",
+        "address_line_2": "ura_line2",
+        "locality": "Cardiff",
+        "care_of": "ura_care_of",
+        "region": "ura_region",
+        "po_box": "ura_po",
+        "supplied_company_name": "ura_cname",
+        "country": "United Kingdom",
+        "postal_code": "CF2 1B6",
+        "usual_country_of_residence": "United Kingdom"
+      }
+    }
+  ],
+  "CreatedTime": "07-JUN-21 15.26.17.000000",
+  "delta_at": "20140925171003950844"
+}

--- a/src/itest/resources/data/natural_officer_delta_out.json
+++ b/src/itest/resources/data/natural_officer_delta_out.json
@@ -1,0 +1,78 @@
+{
+  "id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "data": {
+    "secureOfficer":false,
+    "identificationData": {
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "linksData": {
+      "officer": {
+        "self": "/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self": "/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "pre1992Appointment":false,
+    "service_address": {
+      "address_line_1":"1 Crown Way",
+      "address_line_2":"Pavement",
+      "country":"United Kingdom",
+      "locality":"Cardiff",
+      "postal_code":"CF14 3UZ",
+      "premises":"1",
+      "region":"Cardiff"
+    },
+    "service_address_is_same_as_registered_office_address":true,
+    "appointed_on":1320278400.000000000,
+    "is_pre_1992_appointment":false,
+    "links": {
+      "officer": {
+        "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "nationality":"British",
+    "occupation":"Lawyer",
+    "officer_role":"director",
+    "is_secure_officer":false,
+    "identification": {
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "surname":"GLOVER",
+    "forename":"PHIL",
+    "other_forenames":"Peter",
+    "title":"Mr",
+    "company_number":"01777777",
+    "updated_at":1496665830.000000000
+  },
+  "sensitive_data":{
+    "usual_residential_address":{
+      "address_line_1":"ura_line1",
+      "address_line_2":"ura_line2",
+      "care_of":"ura_care_of",
+      "country":"United Kingdom",
+      "locality":"Cardiff",
+      "po_box":"ura_po",
+      "postal_code":"CF2 1B6",
+      "premises":"URA",
+      "region":"ura_region",
+      "supplied_company_name":"ura_cname"
+    },
+    "date_of_birth":488937600.000000000
+  },
+  "internal_id":"0025987375",
+  "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",
+  "previous_officer_id":"vuIAhYYbRDhqzx9b3e_jd6Uhres",
+  "company_number":"01777777",
+  "delta_at":"20140925171003950844"
+}

--- a/src/itest/resources/data/pre_1992_corporate_officer_delta_in.json
+++ b/src/itest/resources/data/pre_1992_corporate_officer_delta_in.json
@@ -1,0 +1,50 @@
+{
+  "officers": [
+    {
+      "company_number": "01777777",
+      "changed_at": "20170605123030",
+      "kind": "DIRCORP",
+      "internal_id": "0025987375",
+      "appointment_date": "19921103",
+      "appt_date_prefix": "Y",
+      "corporate_ind": "Y",
+      "surname": "MY BIG OLD COMPANY LIMITED",
+      "service_address_same_as_registered_address": "Y",
+      "officer_id": "3001237435",
+      "secure_director": "N",
+      "officer_detail_id": "3456251385",
+      "identification": {
+        "EEA": {
+          "place_registered": "United Kingdom",
+          "registration_number": "38298",
+          "legal_authority": "Chapter 32",
+          "legal_form": "Hong Kong"
+        }
+      },
+      "service_address": {
+        "premise": "1",
+        "address_line_1" : "1 Crown Way",
+        "address_line_2" : "Pavement",
+        "locality" : "Cardiff",
+        "region" : "Cardiff",
+        "postal_code" : "CF14 3UZ",
+        "country": "United Kingdom"
+      },
+      "usual_residential_address": {
+        "premise": "URA",
+        "address_line_1": "ura_line1",
+        "address_line_2": "ura_line2",
+        "locality": "Cardiff",
+        "care_of": "ura_care_of",
+        "region": "ura_region",
+        "po_box": "ura_po",
+        "supplied_company_name": "ura_cname",
+        "country": "United Kingdom",
+        "postal_code": "CF2 1B6",
+        "usual_country_of_residence": "United Kingdom"
+      }
+    }
+  ],
+  "CreatedTime": "07-JUN-21 15.26.17.000000",
+  "delta_at": "20140925171003950844"
+}

--- a/src/itest/resources/data/pre_1992_corporate_officer_delta_out.json
+++ b/src/itest/resources/data/pre_1992_corporate_officer_delta_out.json
@@ -1,0 +1,59 @@
+{
+  "id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "data":{
+    "identificationData":{
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "linksData":{
+      "officer":{
+        "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "pre1992Appointment":true,
+    "service_address":{
+      "address_line_1":"1 Crown Way",
+      "address_line_2":"Pavement",
+      "country":"United Kingdom",
+      "locality":"Cardiff",
+      "postal_code":"CF14 3UZ",
+      "premises":"1",
+      "region":"Cardiff"
+    },
+    "service_address_is_same_as_registered_office_address":true,
+    "appointed_before":720748800.000000000,
+    "is_pre_1992_appointment":true,
+    "links":{
+      "officer":{
+        "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "officer_role":"corporate-director",
+    "identification":{
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "surname":"MY BIG OLD COMPANY LIMITED",
+    "company_number":"01777777",
+    "updated_at":1496665830.000000000
+  },
+  "sensitive_data":{
+
+  },
+  "internal_id":"0025987375",
+  "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",
+  "previous_officer_id":"vuIAhYYbRDhqzx9b3e_jd6Uhres",
+  "company_number":"01777777",
+  "delta_at":"20140925171003950844"
+}

--- a/src/itest/resources/data/pre_1992_natural_officer_delta_in.json
+++ b/src/itest/resources/data/pre_1992_natural_officer_delta_in.json
@@ -1,0 +1,56 @@
+{
+  "officers": [
+    {
+      "company_number": "01777777",
+      "changed_at": "20170605123030",
+      "kind": "DIR",
+      "internal_id": "0025987375",
+      "appointment_date": "19911103",
+      "appt_date_prefix": "Y",
+      "title": "Mr",
+      "corporate_ind": "N",
+      "surname": "GLOVER",
+      "forename": "PHIL",
+      "middle_name": "Peter",
+      "date_of_birth": "19850630",
+      "service_address_same_as_registered_address": "Y",
+      "nationality": "British",
+      "occupation": "Lawyer",
+      "officer_id": "3001237435",
+      "secure_director": "N",
+      "officer_detail_id": "3456251385",
+      "identification": {
+        "EEA": {
+          "place_registered": "United Kingdom",
+          "registration_number": "38298",
+          "legal_authority": "Chapter 32",
+          "legal_form": "Hong Kong"
+        }
+      },
+      "service_address": {
+        "premise": "1",
+        "address_line_1" : "1 Crown Way",
+        "address_line_2" : "Pavement",
+        "locality" : "Cardiff",
+        "region" : "Cardiff",
+        "postal_code" : "CF14 3UZ",
+        "country": "United Kingdom"
+      },
+      "usual_residential_address": {
+        "premise": "URA",
+        "address_line_1": "ura_line1",
+        "address_line_2": "ura_line2",
+        "locality": "Cardiff",
+        "care_of": "ura_care_of",
+        "region": "ura_region",
+        "po_box": "ura_po",
+        "supplied_company_name": "ura_cname",
+        "country": "United Kingdom",
+        "postal_code": "CF2 1B6",
+        "usual_country_of_residence": "United Kingdom"
+      }
+    }
+  ],
+  "CreatedTime": "07-JUN-21 15.26.17.000000",
+  "delta_at": "20140925171003950844"
+}

--- a/src/itest/resources/data/pre_1992_natural_officer_delta_out.json
+++ b/src/itest/resources/data/pre_1992_natural_officer_delta_out.json
@@ -1,0 +1,78 @@
+{
+  "id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "data":{
+    "identificationData":{
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "linksData":{
+      "officer":{
+        "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "secureOfficer":false,
+    "pre1992Appointment":true,
+    "service_address":{
+      "address_line_1":"1 Crown Way",
+      "address_line_2":"Pavement",
+      "country":"United Kingdom",
+      "locality":"Cardiff",
+      "postal_code":"CF14 3UZ",
+      "premises":"1",
+      "region":"Cardiff"
+    },
+    "service_address_is_same_as_registered_office_address":true,
+    "appointed_before":689126400.000000000,
+    "is_pre_1992_appointment":true,
+    "links":{
+      "officer":{
+        "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+        "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+      },
+      "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
+    },
+    "nationality":"British",
+    "occupation":"Lawyer",
+    "officer_role":"director",
+    "is_secure_officer":false,
+    "identification":{
+      "identification_type":"eea",
+      "legal_authority":"Chapter 32",
+      "legal_form":"Hong Kong",
+      "place_registered":"United Kingdom",
+      "registration_number":"38298"
+    },
+    "surname":"GLOVER",
+    "forename":"PHIL",
+    "other_forenames":"Peter",
+    "title":"Mr",
+    "company_number":"01777777",
+    "updated_at":1496665830.000000000
+  },
+  "sensitive_data":{
+    "usual_residential_address":{
+      "address_line_1":"ura_line1",
+      "address_line_2":"ura_line2",
+      "care_of":"ura_care_of",
+      "country":"United Kingdom",
+      "locality":"Cardiff",
+      "po_box":"ura_po",
+      "postal_code":"CF2 1B6",
+      "premises":"URA",
+      "region":"ura_region",
+      "supplied_company_name":"ura_cname"
+    },
+    "date_of_birth":488937600.000000000
+  },
+  "internal_id":"0025987375",
+  "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+  "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",
+  "previous_officer_id":"vuIAhYYbRDhqzx9b3e_jd6Uhres",
+  "company_number":"01777777",
+  "delta_at":"20140925171003950844"
+}

--- a/src/itest/resources/features/OfficerDelta.feature
+++ b/src/itest/resources/features/OfficerDelta.feature
@@ -1,0 +1,21 @@
+Feature: Officer Delta
+
+Scenario: Can transform and send a natural officer
+  Given the application is running
+  When the consumer receives a natural officer delta
+  Then a PUT request is sent to the appointments api with the transformed data
+
+Scenario: Can transform and send a corporate officer
+  Given the application is running
+  When the consumer receives a corporate officer delta
+  Then a PUT request is sent to the appointments api with the transformed data
+
+Scenario: Can transform and send a pre-1992-corporate officer
+  Given the application is running
+  When the consumer receives a pre_1992_corporate officer delta
+  Then a PUT request is sent to the appointments api with the transformed data
+
+Scenario: Can transform and send a pre-1992-natural officer
+  Given the application is running
+  When the consumer receives a pre_1992_natural officer delta
+  Then a PUT request is sent to the appointments api with the transformed data

--- a/src/itest/resources/features/RetriesAndErrors.feature
+++ b/src/itest/resources/features/RetriesAndErrors.feature
@@ -1,0 +1,21 @@
+Feature: Retries and Errors
+
+  Scenario: Process invalid avro message
+    Given the application is running
+    When an invalid avro message is sent
+    Then the message should be moved to topic officer-delta-invalid
+
+  Scenario: Process message with invalid data
+    Given the application is running
+    When a message with invalid data is sent
+    Then the message should be moved to topic officer-delta-invalid
+
+  Scenario: Process message when the data api returns 400
+    Given the application is running
+    When the consumer receives a message but the data api returns a 400
+    Then the message should be moved to topic officer-delta-invalid
+
+  Scenario: Process message when the data api returns 503
+    Given the application is running
+    When the consumer receives a message but the data api returns a 503
+    Then the message should retry 4 times and then error

--- a/src/test/resources/test.properties
+++ b/src/test/resources/test.properties
@@ -1,15 +1,22 @@
-kafka.broker.url=${KAFKA_BROKER_ADDR:localhost:9092}
-spring.main.allow-bean-definition-overriding=true
-KAFKA_BROKER_ADDR=localhost:9092
-KAFKA_TOPICS_LIST=officers-delta
-KAFKA_AUTO_COMMIT=false
-KAFKA_GROUP_NAME=officer-delta-processor
-KAFKA_RESET_OFFSET=false
-MAXIMUM_RETRY_ATTEMPTS=10
-RETRY_THROTTLE_RATE_SECONDS=10
-kafka.polling.duration.ms=2500
-kafka.polling.initial.delay.ms=0
-chs.internal.api.key=12345678
-api.url=api.companieshouse.gov.uk
-payments.api.url=payment.companieshouse.gov.uk
-internal.api.url=internal.api.companieshouse.gov.uk
+kafka.broker.addr=kafka:9092
+kafka.polling.delay.ms=5000
+kafka.odp.group.name=officer-delta-processor
+kafka.error.consumer.mode=false
+officer.delta.processor.attempts=5
+officer.delta.processor.topic: officer-delta
+officer.delta.processor.backoff-delay: 100
+kafka.listener.concurrency: 1
+wiremock.server.port: 8888
+
+management.endpoint.health.enabled=true
+management.endpoint.health.show-details=ALWAYS
+management.endpoints.enabled-by-default=true
+management.endpoints.web.base-path=/officer-delta-processor
+management.endpoints.web.path-mapping.health=/healthCheck
+server.port=8080
+chs.internal.api.key=localhost
+api.url=http://localhost:8888
+payments.api.url=http://localhost:8888
+internal.api.url=http://localhost:8888
+
+logging.level.root=INFO


### PR DESCRIPTION
This PR adds cucumber testing framework, integrations tests covering the main transformations in OfficerTransform (natural officer, corporate officer and pre-1992), updates the make file to run integration tests and add test phony job for concourse.

**Resolves:**
- DSND-1250