### PR TITLE
Fix corporate officers breaking or saving as natural

### DIFF
--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/matcher/OfficerRequestMatcher.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/matcher/OfficerRequestMatcher.java
@@ -17,12 +17,14 @@ public class OfficerRequestMatcher implements ValueMatcher<Request> {
 
     private String expectedOutput;
     private String conumb;
+    private String id;
     private Logger logger;
 
-    public OfficerRequestMatcher(Logger logger, String conumb, String output) {
+    public OfficerRequestMatcher(Logger logger, String conumb, String output, String id) {
         this.conumb = conumb;
         this.expectedOutput = output;
         this.logger = logger;
+        this.id = id;
     }
 
     @Override
@@ -33,7 +35,7 @@ public class OfficerRequestMatcher implements ValueMatcher<Request> {
     }
 
     private MatchResult matchUrl(String actualUrl) {
-        String expectedUrl = "/company/" + conumb + "/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4/full_record";
+        String expectedUrl = "/company/" + conumb + "/appointments/" + id + "/full_record";
 
         MatchResult urlResult = MatchResult.of(expectedUrl.equals(actualUrl));
 

--- a/src/itest/resources/data/corporate_non_corp_kind_officer_delta_in.json
+++ b/src/itest/resources/data/corporate_non_corp_kind_officer_delta_in.json
@@ -1,0 +1,34 @@
+{
+  "officers":[
+    {
+      "company_number":"01777777",
+      "previous_officer_id":"9001808944",
+      "changed_at":"20221109132615529605",
+      "kind":"DIR",
+      "internal_id":"9001808864",
+      "appointment_date":"20221101",
+      "corporate_ind":"Y",
+      "surname":"MY TEST COMPANY III LIMITED",
+      "secure_director":"N",
+      "service_address_same_as_registered_address":"N",
+      "corp_identifier":"TRUE",
+      "officer_id":"9001808944",
+      "officer_detail_id":"9001808811",
+      "changed_at":"20221109132615529605",
+      "service_address":{
+        "premise":"50",
+        "address_line_1":"Stonor Street",
+        "locality":"Stoke-On-Trent",
+        "country":"England",
+        "postal_code":"ST6 3JL"
+      },
+      "identification":{
+        "UK_limited_company":{
+          "registration_number":"222333"
+        }
+      }
+    }
+  ],
+  "CreatedTime":"09-NOV-22 13.27.02.000000",
+  "delta_at":"20221109132615529605"
+}

--- a/src/itest/resources/data/corporate_non_corp_kind_officer_delta_out.json
+++ b/src/itest/resources/data/corporate_non_corp_kind_officer_delta_out.json
@@ -1,0 +1,51 @@
+{
+  "id":"ODxi2KP6LfSvwes9xY0O86YliyM",
+  "data":{
+    "linksData":{
+      "officer":{
+        "self":"/officers/gkfq1cddT1bYG4l0NfBY1ExfEOc",
+        "appointments":"/officers/gkfq1cddT1bYG4l0NfBY1ExfEOc/appointments"
+      },
+      "self":"/company/01777777/appointments/ODxi2KP6LfSvwes9xY0O86YliyM"
+    },
+    "identificationData":{
+      "identification_type":"uk-limited-company",
+      "registration_number":"222333"
+    },
+    "pre1992Appointment":false,
+    "service_address":{
+      "address_line_1":"Stonor Street",
+      "country":"England",
+      "locality":"Stoke-On-Trent",
+      "postal_code":"ST6 3JL",
+      "premises":"50"
+    },
+    "service_address_is_same_as_registered_office_address":false,
+    "appointed_on":1667260800.000000000,
+    "is_pre_1992_appointment":false,
+    "links":{
+      "officer":{
+        "self":"/officers/gkfq1cddT1bYG4l0NfBY1ExfEOc",
+        "appointments":"/officers/gkfq1cddT1bYG4l0NfBY1ExfEOc/appointments"
+      },
+      "self":"/company/01777777/appointments/ODxi2KP6LfSvwes9xY0O86YliyM"
+    },
+    "officer_role":"corporate-director",
+    "identification":{
+      "identification_type":"uk-limited-company",
+      "registration_number":"222333"
+    },
+    "surname":"MY TEST COMPANY III LIMITED",
+    "company_number":"01777777",
+    "updated_at":1668000375.000000000
+  },
+  "sensitive_data":{
+
+  },
+  "internal_id":"9001808864",
+  "appointment_id":"ODxi2KP6LfSvwes9xY0O86YliyM",
+  "officer_id":"gkfq1cddT1bYG4l0NfBY1ExfEOc",
+  "previous_officer_id":"gkfq1cddT1bYG4l0NfBY1ExfEOc",
+  "company_number":"01777777",
+  "delta_at":"20221109132615529605"
+}

--- a/src/itest/resources/features/OfficerDelta.feature
+++ b/src/itest/resources/features/OfficerDelta.feature
@@ -2,20 +2,25 @@ Feature: Officer Delta
 
 Scenario: Can transform and send a natural officer
   Given the application is running
-  When the consumer receives a natural officer delta
+  When the consumer receives a natural officer delta with id EcEKO1YhIKexb0cSDZsn_OHsFw4
   Then a PUT request is sent to the appointments api with the transformed data
 
 Scenario: Can transform and send a corporate officer
   Given the application is running
-  When the consumer receives a corporate officer delta
+  When the consumer receives a corporate officer delta with id EcEKO1YhIKexb0cSDZsn_OHsFw4
   Then a PUT request is sent to the appointments api with the transformed data
 
 Scenario: Can transform and send a pre-1992-corporate officer
   Given the application is running
-  When the consumer receives a pre_1992_corporate officer delta
+  When the consumer receives a pre_1992_corporate officer delta with id EcEKO1YhIKexb0cSDZsn_OHsFw4
   Then a PUT request is sent to the appointments api with the transformed data
 
 Scenario: Can transform and send a pre-1992-natural officer
   Given the application is running
-  When the consumer receives a pre_1992_natural officer delta
+  When the consumer receives a pre_1992_natural officer delta with id EcEKO1YhIKexb0cSDZsn_OHsFw4
+  Then a PUT request is sent to the appointments api with the transformed data
+
+Scenario: Can transform and send a corporate-non-corp-kind officer
+  Given the application is running
+  When the consumer receives a corporate_non_corp_kind officer delta with id ODxi2KP6LfSvwes9xY0O86YliyM
   Then a PUT request is sent to the appointments api with the transformed data

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -58,7 +58,7 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         officer.setSurname(source.getSurname());
         officer.setHonours(source.getHonours());
 
-        final String officerRole = lookupOfficeRole(source.getKind());
+        final String officerRole = lookupOfficeRole(source.getKind(), source.getCorporateInd());
         officer.setOfficerRole(officerRole);
 
         // Occupation and Nationality are in the same set of Roles

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.officer.delta.processor.tranformer;
 
-import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.lookupOfficeRole;
+import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.lookupOfficerRole;
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseDateString;
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseDateTimeString;
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseYesOrNo;
@@ -58,7 +58,7 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         officer.setSurname(source.getSurname());
         officer.setHonours(source.getHonours());
 
-        final String officerRole = lookupOfficeRole(source.getKind(), source.getCorporateInd());
+        final String officerRole = lookupOfficerRole(source.getKind(), source.getCorporateInd());
         officer.setOfficerRole(officerRole);
 
         // Occupation and Nationality are in the same set of Roles

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransform.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.officer.delta.processor.tranformer;
 
 import static org.apache.commons.lang.StringUtils.isNotEmpty;
-import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.lookupOfficeRole;
+import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.lookupOfficerRole;
 import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseDateString;
 
 import org.apache.commons.lang.BooleanUtils;
@@ -28,7 +28,7 @@ public class SensitiveOfficerTransform implements Transformative<OfficersItem, S
 
     @Override
     public SensitiveOfficerAPI transform(OfficersItem source, SensitiveOfficerAPI officer) throws NonRetryableErrorException {
-        final String officerRole = lookupOfficeRole(source.getKind(), source.getCorporateInd());
+        final String officerRole = lookupOfficerRole(source.getKind(), source.getCorporateInd());
         if (RolesWithResidentialAddress.includes(officerRole)) {
             officer.setUsualResidentialAddress(source.getUsualResidentialAddress());
             officer.setResidentialAddressSameAsServiceAddress(

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransform.java
@@ -28,7 +28,7 @@ public class SensitiveOfficerTransform implements Transformative<OfficersItem, S
 
     @Override
     public SensitiveOfficerAPI transform(OfficersItem source, SensitiveOfficerAPI officer) throws NonRetryableErrorException {
-        final String officerRole = lookupOfficeRole(source.getKind());
+        final String officerRole = lookupOfficeRole(source.getKind(), source.getCorporateInd());
         if (RolesWithResidentialAddress.includes(officerRole)) {
             officer.setUsualResidentialAddress(source.getUsualResidentialAddress());
             officer.setResidentialAddressSameAsServiceAddress(

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
@@ -100,7 +100,13 @@ public class TransformerUtils {
         return base64Encode(sha1Digest(plain)).replace("=", "");
     }
 
-    public static String lookupOfficeRole(String kind) {
+    public static String lookupOfficeRole(String kind, String corpInd) {
+        if(corpInd != null) {
+            if(!kind.toUpperCase().contains("CORP") && corpInd.toUpperCase().equals("Y")) {
+                kind += "CORP";
+            }
+        }
+
         OfficerRole officerRole = OfficerRole.valueOf(kind);
 
         return officerRole.getValue();

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
@@ -101,10 +101,9 @@ public class TransformerUtils {
     }
 
     public static String lookupOfficeRole(String kind, String corpInd) {
-        if(corpInd != null) {
-            if(!kind.toUpperCase().contains("CORP") && corpInd.toUpperCase().equals("Y")) {
-                kind += "CORP";
-            }
+        if(corpInd != null && !kind.toUpperCase().contains("CORP")
+                && corpInd.equalsIgnoreCase("Y")) {
+            kind += "CORP";
         }
 
         OfficerRole officerRole = OfficerRole.valueOf(kind);

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
@@ -100,7 +100,7 @@ public class TransformerUtils {
         return base64Encode(sha1Digest(plain)).replace("=", "");
     }
 
-    public static String lookupOfficeRole(String kind, String corpInd) {
+    public static String lookupOfficerRole(String kind, String corpInd) {
         if(corpInd != null && !kind.toUpperCase().contains("CORP")
                 && corpInd.equalsIgnoreCase("Y")) {
             kind += "CORP";

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
@@ -42,6 +42,8 @@ import java.util.stream.Stream;
 class OfficerTransformTest {
     public static final String VALID_DATE = "20000101";
     public static final String INVALID_DATE = "12345";
+    public static final String CORP_IND_Y = "Y";
+    public static final String CORP_IND_N = "N";
     public static final String KIND_OF_OFFICER_ROLE_WITH_DOB = OfficerRole.DIR.name();
     private static final String CHANGED_AT = "20210909133736012345";
     private static final Instant CHANGED_INSTANT = Instant.parse("2021-09-09T13:37:36.000Z");
@@ -278,6 +280,50 @@ class OfficerTransformTest {
             is("/officers/vuIAhYYbRDhqzx9b3e_jd6Uhres"));
         assertThat(result.getLinksData().getOfficerLinksData().getAppointmentsLink(),
             is("/officers/vuIAhYYbRDhqzx9b3e_jd6Uhres/appointments"));
+    }
+
+    @Test
+    void transformCorporateWhenKindIsDIRandCorpIndisY() {
+        final OfficersItem officer = createOfficer(addressAPI, identification);
+
+        officer.setChangedAt(CHANGED_AT);
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+        officer.setCorporateInd(CORP_IND_Y);
+        officer.setKind(OfficerRole.DIR.name());
+
+        final OfficerAPI outputOfficer = testTransform.transform(officer);
+
+        assertThat(outputOfficer.getOfficerRole(), is("corporate-director"));
+    }
+
+    @Test
+    void transformNautralWhenKindIsDIRandCorpIndisN() {
+        final OfficersItem officer = createOfficer(addressAPI, identification);
+
+        officer.setChangedAt(CHANGED_AT);
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+        officer.setCorporateInd(CORP_IND_N);
+        officer.setKind(OfficerRole.DIR.name());
+
+        final OfficerAPI outputOfficer = testTransform.transform(officer);
+
+        assertThat(outputOfficer.getOfficerRole(), is("director"));
+    }
+
+    @Test
+    void transformNaturalWhenKindIsDIRandCorpIndisMissing() {
+        final OfficersItem officer = createOfficer(addressAPI, identification);
+
+        officer.setChangedAt(CHANGED_AT);
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+        officer.setKind(OfficerRole.DIR.name());
+
+        final OfficerAPI outputOfficer = testTransform.transform(officer);
+
+        assertThat(outputOfficer.getOfficerRole(), is("director"));
     }
 
     private void verifyProcessingError(final OfficerAPI officerAPI, final OfficersItem officer,


### PR DESCRIPTION
This PR adds a kind check to the TransformUtils for officers with a corporate indicator set to Y but no CORP in their role name. This is due to records from CHIPS not actually sending out with the CORP attached to the kind name causing corporate officers to either throw a null pointer or save as a natural officer.

Extra integration test added for this scenario and some integration test refactoring.

**Resolves:**
- DSND-1298