### PR TITLE
Remove spaces from kind field

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/TransformerUtils.java
@@ -101,6 +101,7 @@ public class TransformerUtils {
     }
 
     public static String lookupOfficerRole(String kind, String corpInd) {
+        kind = kind.replace(" ","");
         if(corpInd != null && !kind.toUpperCase().contains("CORP")
                 && corpInd.equalsIgnoreCase("Y")) {
             kind += "CORP";

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
@@ -326,6 +326,21 @@ class OfficerTransformTest {
         assertThat(outputOfficer.getOfficerRole(), is("director"));
     }
 
+    @Test
+    void transformCorporateWhenSpacesInKindName() {
+        final OfficersItem officer = createOfficer(addressAPI, identification);
+
+        officer.setChangedAt(CHANGED_AT);
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+        officer.setCorporateInd(CORP_IND_Y);
+        officer.setKind("D IR ");
+
+        final OfficerAPI outputOfficer = testTransform.transform(officer);
+
+        assertThat(outputOfficer.getOfficerRole(), is("corporate-director"));
+    }
+
     private void verifyProcessingError(final OfficerAPI officerAPI, final OfficersItem officer,
             final String expectedMessage) {
         final NonRetryableErrorException exception =


### PR DESCRIPTION
This PR adds logic to remove spaces from the kind field before mapping it to role. This is due to the NOMDIR being sent from CHIPS with a tailing whitespace that breaks corporate submissions.

**Resolves:**
- DSND-1298