### PR TITLE
Add delete endpoint call

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,9 +22,9 @@
 
 		<avro.version>1.8.1</avro.version>
 		<ch-kafka.version>1.4.4</ch-kafka.version>
-		<kafka-models.version>1.0.25</kafka-models.version>
+		<kafka-models.version>1.0.28</kafka-models.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
-		<private.sdk.version>2.0.198</private.sdk.version>
+		<private.sdk.version>2.0.199</private.sdk.version>
 		<spring.boot.version>2.6.4</spring.boot.version>
 
 		<!-- Logging -->

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/consumer/OfficerDeltaProcessorITest.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/consumer/OfficerDeltaProcessorITest.java
@@ -17,7 +17,7 @@ public class OfficerDeltaProcessorITest extends AbstractIntegrationTest {
 
     @Test
     public void testSendingKafkaMessage() {
-        ChsDelta chsDelta = new ChsDelta("{ \"key\": \"value\" }", 1, "some_id");
+        ChsDelta chsDelta = new ChsDelta("{ \"key\": \"value\" }", 1, "some_id", false);
         kafkaTemplate.send(mainTopic, chsDelta);
     }
 

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/data/TestData.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/data/TestData.java
@@ -19,6 +19,11 @@ public class TestData {
         return readFile(path).replaceAll("\n", "");
     }
 
+    public static String getDeleteData() {
+        String path = "src/itest/resources/data/delete_delta.json";
+        return readFile(path).replaceAll("\n", "");
+    }
+
     private static String readFile(String path) {
         String data;
         try {

--- a/src/itest/resources/data/delete_delta.json
+++ b/src/itest/resources/data/delete_delta.json
@@ -1,0 +1,6 @@
+{
+  "internal_id": "3102598777",
+  "company_number": "09876543",
+  "officer_id": "3001237435",
+  "action": "DELETE"
+}

--- a/src/itest/resources/features/Delete.feature
+++ b/src/itest/resources/features/Delete.feature
@@ -1,0 +1,6 @@
+Feature: Delete
+
+  Scenario: send DELETE request to appointments Api
+    Given the application is running
+    When the consumer receives a delete payload
+    Then a DELETE request is sent to the appointments api with the encoded Id and company number

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
@@ -55,14 +55,18 @@ public class DeltaConsumer {
                                     @Header(KafkaHeaders.RECEIVED_PARTITION_ID) String partition,
                                     @Header(KafkaHeaders.OFFSET) String offset) {
         var startTime = Instant.now();
-        var chsDelta = message.getPayload();
+        ChsDelta chsDelta = message.getPayload();
         String contextId = chsDelta.getContextId();
         logger.info(format("A new message successfully picked up from topic: %s, "
                         + "partition: %s and offset: %s with contextId: %s",
                 topic, partition, offset, contextId));
 
         try {
-            processor.process(chsDelta);
+            if (Boolean.TRUE.equals(chsDelta.getIsDelete())) {
+                processor.processDelete(chsDelta);
+            } else {
+                processor.process(chsDelta);
+            }
             logger.info(format("Officer Delta message with contextId: %s is successfully "
                             + "processed in %d milliseconds", contextId,
                     Duration.between(startTime, Instant.now()).toMillis()));

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
@@ -55,7 +55,7 @@ public class DeltaConsumer {
                                     @Header(KafkaHeaders.RECEIVED_PARTITION_ID) String partition,
                                     @Header(KafkaHeaders.OFFSET) String offset) {
         var startTime = Instant.now();
-        ChsDelta chsDelta = message.getPayload();
+        var chsDelta = message.getPayload();
         String contextId = chsDelta.getContextId();
         logger.info(format("A new message successfully picked up from topic: %s, "
                         + "partition: %s and offset: %s with contextId: %s",

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
@@ -95,7 +95,7 @@ public class DeltaProcessor implements Processor<ChsDelta> {
         final String internalId;
         final String companyNumber;
 
-        ObjectMapper mapper = new ObjectMapper();
+        var mapper = new ObjectMapper();
         OfficerDeleteDelta officersDelete;
         try {
             officersDelete = mapper.readValue(chsDelta.getData(),

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
@@ -92,21 +92,22 @@ public class DeltaProcessor implements Processor<ChsDelta> {
     @Override
     public void processDelete(ChsDelta chsDelta) {
         final String logContext = chsDelta.getContextId();
-        final String internalId;
-        final String companyNumber;
+        final Map<String, Object> logMap = new HashMap<>();
 
         var mapper = new ObjectMapper();
         OfficerDeleteDelta officersDelete;
         try {
             officersDelete = mapper.readValue(chsDelta.getData(),
                     OfficerDeleteDelta.class);
+        final String companyNumber = officersDelete.getCompanyNumber();
+        final String internalId = TransformerUtils.encode(officersDelete.getInternalId());
+            apiClientService.deleteAppointment(logContext, internalId, companyNumber);
+        } catch (ResponseStatusException e) {
+            handleResponse(e, e.getStatus(), logContext, "Sending officer delete failed", logMap);
         } catch (Exception ex) {
             throw new NonRetryableErrorException(
                     "Error when extracting officers delete delta", ex);
         }
-        companyNumber = officersDelete.getCompanyNumber();
-        internalId = TransformerUtils.encode(officersDelete.getInternalId());
-        apiClientService.deleteAppointment(logContext, internalId, companyNumber);
     }
 
     private void handleResponse(final ResponseStatusException ex, final HttpStatus httpStatus, final String logContext,

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/Processor.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/Processor.java
@@ -5,4 +5,5 @@ import uk.gov.companieshouse.officer.delta.processor.exception.RetryableErrorExc
 
 public interface Processor<I> {
     void process(I delta) throws RetryableErrorException, NonRetryableErrorException;
+    void processDelete(I delta) throws NonRetryableErrorException;
 }

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientService.java
@@ -25,4 +25,14 @@ public interface ApiClientService {
      */
     ApiResponse<Void> putAppointment(final String logContext, final String companyNumber, final AppointmentAPI appointment);
 
+    /**
+     * Delete a Company Appointment.
+     *
+     *
+     * @param logContext
+     * @param internalId the internal Id
+     * @param companyNumber the company number
+     * @return the api response
+     */
+    ApiResponse<Void> deleteAppointment(final String logContext, final String internalId,final String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImpl.java
@@ -73,6 +73,22 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
                         .upsert(uri, appointment));
     }
 
+    @Override
+    public ApiResponse<Void> deleteAppointment(
+            final String log, final String internalId,
+            final String companyNumber) {
+        final String uri =
+                String.format("/company/%s/appointments/%s/full_record/delete",
+                        companyNumber, internalId);
+
+        Map<String,Object> logMap = createLogMap(internalId,"DELETE", uri);
+        logger.infoContext(log, String.format("DELETE %s", uri), logMap);
+
+        return executeOp(log, "deleteOfficer", uri,
+                getApiClient(log).privateDisqualificationResourceHandler()
+                        .deleteOfficer(uri));
+    }
+
     private Map<String,Object> createLogMap(String companyNumber, String method, String path){
         final Map<String, Object> logMap = new HashMap<>();
         logMap.put("company_number", companyNumber);

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImpl.java
@@ -61,7 +61,7 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
 
     @Override
     public ApiResponse<Void> putAppointment(final String logContext, String companyNumber, AppointmentAPI appointment) {
-        final String uri =
+        final var uri =
                 String.format("/company/%s/appointments/%s/full_record", companyNumber, appointment.getAppointmentId());
 
         Map<String,Object> logMap = createLogMap(companyNumber,"PUT", uri);

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImpl.java
@@ -77,7 +77,7 @@ public class ApiClientServiceImpl extends BaseApiClientServiceImpl implements Ap
     public ApiResponse<Void> deleteAppointment(
             final String log, final String internalId,
             final String companyNumber) {
-        final String uri =
+        final var uri =
                 String.format("/company/%s/appointments/%s/full_record/delete",
                         companyNumber, internalId);
 

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/Util.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/Util.java
@@ -56,19 +56,20 @@ public class Util {
         return record;
     }
 
-    public static Message<ChsDelta> createChsDeltaMessage(String filename) throws IOException {
+    public static Message<ChsDelta> createChsDeltaMessage(String filename, boolean isDelete) throws IOException {
         InputStreamReader exampleJsonPayload = new InputStreamReader(
                 ClassLoader.getSystemClassLoader().getResourceAsStream(filename));
         String data = FileCopyUtils.copyToString(exampleJsonPayload);
 
-        return buildMessage(data);
+        return buildMessage(data, isDelete);
     }
 
-    private static Message<ChsDelta> buildMessage(String data) {
+    private static Message<ChsDelta> buildMessage(String data, boolean isDelete) {
         ChsDelta mockChsDelta = ChsDelta.newBuilder()
                 .setData(data)
                 .setContextId("context_id")
                 .setAttempt(1)
+                .setIsDelete(isDelete)
                 .build();
         return MessageBuilder
                 .withPayload(mockChsDelta)

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
@@ -35,15 +35,23 @@ class DeltaConsumerTest {
 
     @Test
     void When_consumer_receives_valid_payload_process_is_called() throws IOException {
-        Message<ChsDelta> message = Util.createChsDeltaMessage("officer_delta_example.json");
+        Message<ChsDelta> message = Util.createChsDeltaMessage("officer_delta_example.json", false);
         consumer.receiveMainMessages(message, "topic", "partition", "offset");
 
         verify(processor).process(any());
     }
 
     @Test
+    void When_consumer_receives_valid_delete_payload_processDelete_is_called() throws IOException {
+        Message<ChsDelta> message = Util.createChsDeltaMessage("officer_delete_delta.json", true);
+        consumer.receiveMainMessages(message, "topic", "partition", "offset");
+
+        verify(processor).processDelete(any());
+    }
+
+    @Test
     void When_processor_throws_exception_consumer_throws_exception() throws IOException {
-        Message<ChsDelta> message = Util.createChsDeltaMessage("broken_delta.json");
+        Message<ChsDelta> message = Util.createChsDeltaMessage("broken_delta.json", false);
         ChsDelta brokenMessage = message.getPayload();
 
         doThrow(new NonRetryableErrorException(new Exception()))

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
@@ -40,7 +40,11 @@ import uk.gov.companieshouse.officer.delta.processor.exception.RetryableErrorExc
 import uk.gov.companieshouse.officer.delta.processor.model.Officers;
 import uk.gov.companieshouse.officer.delta.processor.model.OfficersItem;
 import uk.gov.companieshouse.officer.delta.processor.service.api.ApiClientService;
-import uk.gov.companieshouse.officer.delta.processor.tranformer.*;
+import uk.gov.companieshouse.officer.delta.processor.tranformer.AppointmentTransform;
+import uk.gov.companieshouse.officer.delta.processor.tranformer.IdentificationTransform;
+import uk.gov.companieshouse.officer.delta.processor.tranformer.OfficerTransform;
+import uk.gov.companieshouse.officer.delta.processor.tranformer.SensitiveOfficerTransform;
+import uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils;
 
 import java.io.BufferedReader;
 import java.io.IOException;

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/serialization/ChsDeltaDeserializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/serialization/ChsDeltaDeserializerTest.java
@@ -26,7 +26,7 @@ class ChsDeltaDeserializerTest {
 
     @Test
     void When_deserialize_Expect_ValidChsDeltaObject() {
-        ChsDelta chsDelta = new ChsDelta("{\"key\": \"value\"}", 1, "context_id");
+        ChsDelta chsDelta = new ChsDelta("{\"key\": \"value\"}", 1, "context_id", false);
         byte[] data = encodedData(chsDelta);
 
         ChsDelta deserializedObject = deserializer.deserialize("", data);

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/serialization/ChsDeltaSerializerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/serialization/ChsDeltaSerializerTest.java
@@ -24,7 +24,7 @@ class ChsDeltaSerializerTest {
 
     @Test
     void When_serialize_Expect_chsDeltaBytes() {
-        ChsDelta chsDelta = new ChsDelta("{\"key\": \"value\"}", 1, "context_id");
+        ChsDelta chsDelta = new ChsDelta("{\"key\": \"value\"}", 1, "context_id", false);
 
         byte[] result = serializer.serialize("", chsDelta);
 

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImplTest.java
@@ -1,0 +1,76 @@
+package uk.gov.companieshouse.officer.delta.processor.service.api;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.util.ReflectionTestUtils;
+import uk.gov.companieshouse.api.handler.delta.company.appointment.request.PrivateOfficerDelete;
+import uk.gov.companieshouse.api.handler.delta.company.appointment.request.PrivateOfficersUpsert;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.api.model.delta.officers.AppointmentAPI;
+import uk.gov.companieshouse.logging.Logger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.verify;
+
+
+@ExtendWith(MockitoExtension.class)
+class ApiClientServiceImplTest {
+
+    @Mock
+    Logger logger;
+
+    private ApiClientServiceImpl apiClientService;
+
+    @BeforeEach
+    void setup() {
+        apiClientService = new ApiClientServiceImpl(logger);
+        ReflectionTestUtils.setField(apiClientService, "chsApiKey", "apiKey");
+        ReflectionTestUtils.setField(apiClientService, "apiUrl", "https://api.companieshouse.gov.uk");
+    }
+
+    @Test
+    void putAppointment() {
+        final ApiResponse<Void> expectedResponse = new ApiResponse<>(HttpStatus.OK.value(), null, null);
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+        doReturn(expectedResponse).when(apiClientServiceSpy).executeOp(anyString(), anyString(),
+                anyString(),
+                any(PrivateOfficersUpsert.class));
+        var appointmentApi = new AppointmentAPI();
+        appointmentApi.setAppointmentId("3102598777");
+        ApiResponse<Void> response = apiClientServiceSpy.putAppointment("context_id",
+                "09876543",
+                appointmentApi);
+        verify(apiClientServiceSpy).executeOp(anyString(), eq("putCompanyAppointment"),
+                eq("/company/09876543/appointments/3102598777/full_record"),
+                any(PrivateOfficersUpsert.class));
+
+        assertThat(response).isEqualTo(expectedResponse);
+    }
+
+    @Test
+    void deleteDisqualification() {
+        final ApiResponse<Void> expectedResponse = new ApiResponse<>(HttpStatus.OK.value(), null, null);
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+        doReturn(expectedResponse).when(apiClientServiceSpy).executeOp(anyString(), anyString(),
+                anyString(),
+                any(PrivateOfficerDelete.class));
+
+        ApiResponse<Void> response = apiClientServiceSpy.deleteAppointment("context_id",
+                "N-YqKNwdT_HvetusfTJ0H0jAQbA", "09876543");
+        verify(apiClientServiceSpy).executeOp(anyString(), eq("deleteOfficer"),
+                eq("/company/09876543/appointments/N-YqKNwdT_HvetusfTJ0H0jAQbA/full_record/delete"),
+                any(PrivateOfficerDelete.class));
+
+        assertThat(response).isEqualTo(expectedResponse);
+    }
+}
+
+
+

--- a/src/test/resources/officer_delete_delta.json
+++ b/src/test/resources/officer_delete_delta.json
@@ -1,0 +1,6 @@
+{
+  "internal_id": "3102598777",
+  "company_number": "09876543",
+  "officer_id": "3001237435",
+  "action": "DELETE"
+}


### PR DESCRIPTION
This PR checks the delete flag of an incoming CHS delta payload and adds a processDelete method in the processor to map the payload to an OfficerDeleteDelta object, extract the internal_id and company_number to build the API uri and calls the appointments API delete endpoint.
Unit tests and integration tests added for delete functionality.

**Resolves:**
- DSND-1321