### PR TITLE
Add person number field to officer

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 		<ch-kafka.version>1.4.4</ch-kafka.version>
 		<kafka-models.version>1.0.28</kafka-models.version>
 		<commons-lang3.version>3.11</commons-lang3.version>
-		<private.sdk.version>2.0.204</private.sdk.version>
+		<private.sdk.version>2.0.209</private.sdk.version>
 		<spring.boot.version>2.6.4</spring.boot.version>
 
 		<!-- Logging -->

--- a/src/itest/resources/data/natural_officer_delta_in.json
+++ b/src/itest/resources/data/natural_officer_delta_in.json
@@ -8,6 +8,7 @@
       "appointment_date": "20111103",
       "title": "Mr",
       "corporate_ind": "N",
+      "person_number": "1234567890",
       "surname": "GLOVER",
       "forename": "PHIL",
       "middle_name": "Peter",

--- a/src/itest/resources/data/natural_officer_delta_out.json
+++ b/src/itest/resources/data/natural_officer_delta_out.json
@@ -17,6 +17,7 @@
       "self": "/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4"
     },
     "pre1992Appointment":false,
+    "person_number": "1234567890",
     "service_address": {
       "address_line_1":"1 Crown Way",
       "address_line_2":"Pavement",

--- a/src/itest/resources/data/pre_1992_natural_officer_delta_in.json
+++ b/src/itest/resources/data/pre_1992_natural_officer_delta_in.json
@@ -5,6 +5,7 @@
       "changed_at": "20170605123030",
       "kind": "DIR",
       "internal_id": "0025987375",
+      "person_number": "1234567890",
       "appointment_date": "19911103",
       "appt_date_prefix": "Y",
       "title": "Mr",

--- a/src/itest/resources/data/pre_1992_natural_officer_delta_out.json
+++ b/src/itest/resources/data/pre_1992_natural_officer_delta_out.json
@@ -17,6 +17,7 @@
     },
     "secureOfficer":false,
     "pre1992Appointment":true,
+    "person_number": "1234567890",
     "service_address":{
       "address_line_1":"1 Crown Way",
       "address_line_2":"Pavement",

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItem.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItem.java
@@ -90,6 +90,9 @@ public class OfficersItem {
     @JsonProperty("surname")
     private String surname;
 
+    @JsonProperty("person_number")
+    private String personNumber;
+
     @JsonProperty(value = "secure_director", required = true)
     private String secureDirector;
 
@@ -326,6 +329,10 @@ public class OfficersItem {
         this.previousNameArray = previousNameArray;
     }
 
+    public String getPersonNumber() { return personNumber; }
+
+    public void setPersonNumber(String personNumber) { this.personNumber = personNumber; }
+
     @Override
     public boolean equals(final Object o) {
         if (this == o) {
@@ -366,6 +373,7 @@ public class OfficersItem {
                 && Objects.equals(getIdentification(), that.getIdentification())
                 && Objects.equals(getNationality(), that.getNationality())
                 && Objects.equals(getSurname(), that.getSurname())
+                && Objects.equals(getPersonNumber(), that.getPersonNumber())
                 && Objects.equals(getSecureDirector(), that.getSecureDirector())
                 && Objects.equals(getPreviousNameArray(), that.getPreviousNameArray())
                 && Objects.equals(getAdditionalProperties(), that.getAdditionalProperties());
@@ -398,6 +406,7 @@ public class OfficersItem {
                 getIdentification(),
                 getNationality(),
                 getSurname(),
+                getPersonNumber(),
                 getSecureDirector(),
                 getPreviousNameArray(),
                 getAdditionalProperties());

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -66,6 +66,7 @@ public class OfficerTransform implements Transformative<OfficersItem, OfficerAPI
         }
 
         officer.setCompanyNumber(source.getCompanyNumber());
+        officer.setPersonNumber(source.getPersonNumber());
 
         // Occupation and Nationality are in the same set of Roles
         if (RolesWithOccupation.includes(officerRole)) {

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItemTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/OfficersItemTest.java
@@ -66,6 +66,12 @@ class OfficersItemTest {
     }
 
     @Test
+    void setPersonNumber() {
+        testItem.setPersonNumber(EXPECTED);
+        assertThat(testItem.getPersonNumber(), is(EXPECTED));
+    }
+
+    @Test
     void setServiceAddressSameAsRegisteredAddress() {
         testItem.setServiceAddressSameAsRegisteredAddress(EXPECTED);
         assertThat(testItem.getServiceAddressSameAsRegisteredAddress(), is(EXPECTED));
@@ -217,6 +223,7 @@ class OfficersItemTest {
                         containsString("changedAt=<null>"),
                         containsString("companyNumber=<null>"),
                         containsString("corporateInd=<null>"),
+                        containsString("personNumber=<null>"),
                         containsString("dateOfBirth=<null>"),
                         containsString("forename=<null>"),
                         containsString("honours=<null>"),

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
@@ -257,6 +257,7 @@ class OfficerTransformTest {
         assertThat(result.getNationality(), is(officer.getNationality()));
         assertThat(result.getOccupation(), is(officer.getOccupation()));
         assertThat(result.getHonours(), is(officer.getHonours()));
+        assertThat(result.getPersonNumber(), is(officer.getPersonNumber()));
         assertThat(result.getServiceAddress(), is(sameInstance(addressAPI)));
         assertThat(result.isServiceAddressSameAsRegisteredOfficeAddress(), is(true));
         assertThat(result.getIdentificationData(), is(sameInstance(identificationAPI)));
@@ -375,6 +376,7 @@ class OfficerTransformTest {
         item.setResidentialAddressSameAsServiceAddress("Y");
         item.setIdentification(identification);
         item.setCorporateInd("N");
+        item.setPersonNumber("1234567890");
 
         return item;
     }


### PR DESCRIPTION
This PR updates the POM with latest private-api-sdk which includes the personNumber field in the OfficerAPI class. Additionally it adds this personNumber field to the OfficerItem class and sets it in the OfficerTransform.
Unit tests and integration tests have been updated with this field too.

**Resolves:**
- DSND-1401