### PR TITLE
Add managing officer

### DIFF
--- a/src/itest/resources/data/managing_officer_delta_in.json
+++ b/src/itest/resources/data/managing_officer_delta_in.json
@@ -1,0 +1,57 @@
+{
+  "officers": [
+    {
+      "company_number": "01777777",
+      "changed_at": "20170605123030",
+      "kind": "MANOFF",
+      "internal_id": "0025987375",
+      "appointment_date": "20111103",
+      "title": "Mr",
+      "corporate_ind": "N",
+      "person_number": "1234567890",
+      "surname": "GLOVER",
+      "forename": "PHIL",
+      "middle_name": "Peter",
+      "date_of_birth": "19850630",
+      "service_address_same_as_registered_address": "Y",
+      "nationality": "British",
+      "occupation": "Lawyer",
+      "officer_id": "3001237435",
+      "responsibilities": "my responsibilities",
+      "secure_director": "N",
+      "officer_detail_id": "3456251385",
+      "identification": {
+        "EEA": {
+          "place_registered": "United Kingdom",
+          "registration_number": "38298",
+          "legal_authority": "Chapter 32",
+          "legal_form": "Hong Kong"
+        }
+      },
+      "service_address": {
+        "premise": "1",
+        "address_line_1" : "1 Crown Way",
+        "address_line_2" : "Pavement",
+        "locality" : "Cardiff",
+        "region" : "Cardiff",
+        "postal_code" : "CF14 3UZ",
+        "country": "United Kingdom"
+      },
+      "usual_residential_address": {
+        "premise": "URA",
+        "address_line_1": "ura_line1",
+        "address_line_2": "ura_line2",
+        "locality": "Cardiff",
+        "care_of": "ura_care_of",
+        "region": "ura_region",
+        "po_box": "ura_po",
+        "supplied_company_name": "ura_cname",
+        "country": "United Kingdom",
+        "postal_code": "CF2 1B6",
+        "usual_country_of_residence": "United Kingdom"
+      }
+    }
+  ],
+  "CreatedTime": "07-JUN-21 15.26.17.000000",
+  "delta_at": "20140925171003950844"
+}

--- a/src/itest/resources/data/managing_officer_delta_out.json
+++ b/src/itest/resources/data/managing_officer_delta_out.json
@@ -1,0 +1,91 @@
+{
+  "external_data":{
+    "data":{
+      "person_number":"1234567890",
+      "service_address":{
+        "address_line_1":"1 Crown Way",
+        "address_line_2":"Pavement",
+        "country":"United Kingdom",
+        "locality":"Cardiff",
+        "postal_code":"CF14 3UZ",
+        "premises":"1",
+        "region":"Cardiff"
+      },
+      "service_address_same_as_registered_office_address":true,
+      "country_of_residence":null,
+      "appointed_on":[
+        2011,
+        11,
+        3
+      ],
+      "appointed_before":null,
+      "is_pre_1992_appointment":false,
+      "links":[
+        {
+          "self":"/company/01777777/appointments/EcEKO1YhIKexb0cSDZsn_OHsFw4",
+          "officer":{
+            "self":"/officers/r4Aq2-D3appznoESN24MtsLovfo",
+            "appointments":"/officers/r4Aq2-D3appznoESN24MtsLovfo/appointments"
+          }
+        }
+      ],
+      "nationality":"British",
+      "occupation":"Lawyer",
+      "officer_role":"managing-officer",
+      "is_secure_officer":false,
+      "identification":{
+        "identification_type":"eea",
+        "legal_authority":"Chapter 32",
+        "legal_form":"Hong Kong",
+        "place_registered":"United Kingdom",
+        "registration_number":"38298"
+      },
+      "company_name":null,
+      "surname":"GLOVER",
+      "forename":"PHIL",
+      "honours":null,
+      "other_forenames":"Peter",
+      "title":"Mr",
+      "company_number":"01777777",
+      "contact_details":null,
+      "principal_office_address":null,
+      "resigned_on":null,
+      "responsibilities": "my responsibilities",
+      "former_names":null
+    },
+    "sensitive_data":{
+      "usual_residential_address":{
+        "address_line_1":"ura_line1",
+        "address_line_2":"ura_line2",
+        "care_of":"ura_care_of",
+        "country":"United Kingdom",
+        "locality":"Cardiff",
+        "po_box":"ura_po",
+        "postal_code":"CF2 1B6",
+        "premises":"URA",
+        "region":"ura_region"
+      },
+      "residential_address_same_as_service_address":null,
+      "date_of_birth":{
+        "day":30,
+        "month":6,
+        "year":1985
+      }
+    },
+    "internal_id":"0025987375",
+    "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
+    "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",
+    "previous_officer_id":"vuIAhYYbRDhqzx9b3e_jd6Uhres",
+    "company_number":"01777777"
+  },
+  "internal_data":{
+    "delta_at":1.411661403E9,
+    "updated_by":null,
+    "updated_at":[
+      2017,
+      6,
+      5
+    ],
+    "officer_role_sort_order":2
+  }
+}

--- a/src/itest/resources/features/OfficerDelta.feature
+++ b/src/itest/resources/features/OfficerDelta.feature
@@ -29,3 +29,8 @@ Scenario: Can transform and send a corporate-managing officer
   Given the application is running
   When the consumer receives a corporate_managing officer delta with id EcEKO1YhIKexb0cSDZsn_OHsFw4
   Then a PUT request is sent to the appointments api with the transformed data
+
+Scenario: Can transform and send a managing officer
+  Given the application is running
+  When the consumer receives a managing officer delta with id EcEKO1YhIKexb0cSDZsn_OHsFw4
+  Then a PUT request is sent to the appointments api with the transformed data

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/OfficerRole.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/OfficerRole.java
@@ -32,6 +32,7 @@ public enum OfficerRole {
     RECMAN("receiver-and-manager"),
     SEC("secretary"),
     SECCORP("corporate-secretary"),
+    MANOFF("managing-officer"),
     MANOFFCORP("corporate-managing-officer");
 
     private final String value;

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithCountryOfResidence.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithCountryOfResidence.java
@@ -10,7 +10,8 @@ public enum RolesWithCountryOfResidence {
     MEMMANORG(OfficerRole.MEMMANORG),
     MEMSUPORG(OfficerRole.MEMSUPORG),
     MEMADMORG(OfficerRole.MEMADMORG),
-    NOMDIR(OfficerRole.NOMDIR);
+    NOMDIR(OfficerRole.NOMDIR),
+    MANOFF(OfficerRole.MANOFF);
 
     private final OfficerRole officerRole;
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithDateOfBirth.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithDateOfBirth.java
@@ -9,7 +9,8 @@ public enum RolesWithDateOfBirth {
     MEMBER_OF_A_MANAGEMENT_ORGAN(OfficerRole.MEMMANORG),
     MEMBER_OF_A_SUPERVISORY_ORGAN(OfficerRole.MEMSUPORG),
     MEMBER_OF_AN_ADMINISTRATIVE_ORGAN(OfficerRole.MEMADMORG),
-    NOMINEE_DIRECTOR(OfficerRole.NOMDIR);
+    NOMINEE_DIRECTOR(OfficerRole.NOMDIR),
+    MANOFF(OfficerRole.MANOFF);
 
     private final OfficerRole officerRole;
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithFormerNames.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithFormerNames.java
@@ -12,7 +12,8 @@ public enum RolesWithFormerNames {
     MEMBER_OF_AN_ADMINISTRATIVE_ORGAN(OfficerRole.MEMADMORG),
     NOMINEE_DIRECTOR(OfficerRole.NOMDIR),
     NOM_SEC(OfficerRole.NOMSEC),
-    SEC(OfficerRole.SEC);
+    SEC(OfficerRole.SEC),
+    MANOFF(OfficerRole.MANOFF);
 
     private final OfficerRole officerRole;
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithOccupation.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithOccupation.java
@@ -10,7 +10,8 @@ public enum RolesWithOccupation {
     MEMBER_OF_AN_ADMINISTRATIVE_ORGAN(OfficerRole.MEMADMORG),
     NOMINEE_DIRECTOR(OfficerRole.NOMDIR),
     NOMINEE_SECRETARY(OfficerRole.NOMSEC),
-    SECRETARY(OfficerRole.SEC);
+    SECRETARY(OfficerRole.SEC),
+    MANOFF(OfficerRole.MANOFF);
 
     private final OfficerRole officerRole;
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithResidentialAddress.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/RolesWithResidentialAddress.java
@@ -12,7 +12,8 @@ public enum RolesWithResidentialAddress {
     MEMBER_OF_AN_ADMINISTRATIVE_ORGAN(OfficerRole.MEMADMORG),
     NOMINEE_DIRECTOR(OfficerRole.NOMDIR),
     PERSAUTHR(OfficerRole.PERSAUTHR),
-    PERSAUTHRA(OfficerRole.PERSAUTHRA);
+    PERSAUTHRA(OfficerRole.PERSAUTHRA),
+    MANOFF(OfficerRole.MANOFF);
 
     private final OfficerRole officerRole;
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -7,7 +7,6 @@ import static uk.gov.companieshouse.officer.delta.processor.tranformer.Transform
 import org.apache.commons.lang.BooleanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
-import uk.gov.companieshouse.api.appointment.ContactDetails;
 import uk.gov.companieshouse.api.appointment.Data;
 import uk.gov.companieshouse.api.appointment.ItemLinkTypes;
 import uk.gov.companieshouse.api.appointment.OfficerLinkTypes;
@@ -89,15 +88,7 @@ public class OfficerTransform implements Transformative<OfficersItem, Data> {
         final var appointmentDate = parseLocalDate(
                 "appointmentDate", source.getAppointmentDate());
 
-        if(officerRole.contains(OfficerRole.MANOFF.getValue())) {
-            officer.setResponsibilities(source.getResponsibilities());
-        }
-
-        if(OfficerRole.MANOFFCORP.getValue().equals(officerRole)) {
-            officer.setPrincipalOfficeAddress(principalOfficeAddressTransform.transform(source.getPrincipalOfficeAddress()));
-            officer.setContactDetails(source.getContactDetails());
-        }
-
+        handleManagingOfficerFields(source, officer, officerRole);
 
         if (RolesWithPre1992Appointment.includes(officerRole)) {
             officer.setIsPre1992Appointment(parseYesOrNo(source.getApptDatePrefix()));
@@ -149,6 +140,17 @@ public class OfficerTransform implements Transformative<OfficersItem, Data> {
         officer.setLinks(Collections.singletonList(itemLinkTypes));
 
         return officer;
+    }
+
+    private void handleManagingOfficerFields(OfficersItem source, Data officer, String officerRole) {
+        if(officerRole.contains(OfficerRole.MANOFF.getValue())) {
+            officer.setResponsibilities(source.getResponsibilities());
+        }
+
+        if(OfficerRole.MANOFFCORP.getValue().equals(officerRole)) {
+            officer.setPrincipalOfficeAddress(principalOfficeAddressTransform.transform(source.getPrincipalOfficeAddress()));
+            officer.setContactDetails(source.getContactDetails());
+        }
     }
 }
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransform.java
@@ -89,10 +89,13 @@ public class OfficerTransform implements Transformative<OfficersItem, Data> {
         final var appointmentDate = parseLocalDate(
                 "appointmentDate", source.getAppointmentDate());
 
+        if(officerRole.contains(OfficerRole.MANOFF.getValue())) {
+            officer.setResponsibilities(source.getResponsibilities());
+        }
+
         if(OfficerRole.MANOFFCORP.getValue().equals(officerRole)) {
             officer.setPrincipalOfficeAddress(principalOfficeAddressTransform.transform(source.getPrincipalOfficeAddress()));
             officer.setContactDetails(source.getContactDetails());
-            officer.setResponsibilities(source.getResponsibilities());
         }
 
 

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/OfficerTransformTest.java
@@ -280,6 +280,25 @@ class OfficerTransformTest {
         assertThat(result.getResponsibilities(), is("test"));
     }
 
+    @Test
+    void testManagingOfficerTransform() throws NonRetryableErrorException {
+        Data officerAPI = testTransform.factory();
+        OfficersItem officer = createOfficer(addressAPI, identification);
+
+        officer.setKind(OfficerRole.MANOFF.name());
+        officer.setResponsibilities("test");
+
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+
+        when(identificationTransform.transform(identification)).thenReturn(identificationAPI);
+
+        final Data result = testTransform.transform(officer, officerAPI);
+
+        assertThat(result.getOfficerRole().getValue(), is("managing-officer"));
+        assertThat(result.getResponsibilities(), is("test"));
+    }
+
     @DisplayName("Verify data in the Links object is created as expected")
     @Test
     void verifyLinksData() throws NonRetryableErrorException {


### PR DESCRIPTION
This PR adds the managing officer role to the officer roles, roles with occupation, roles with residential address, roles with forenames and roles with date of birth enums. It also adds a role check to set responsibilities.
Integration test case and unit test added.

**Resolves:**
- DSND-1426