### PR TITLE
DSND-2017: Fix company status enum bug

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/CompanyStatus.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/model/enums/CompanyStatus.java
@@ -14,7 +14,7 @@ public enum CompanyStatus {
     OPEN(List.of("8"), "open"),
     CLOSED(List.of("9"), "closed"),
     INSOLVENCY_PROCEEDINGS(List.of("C", "E", "H", "J", "K", "L", "N", "O", "P", "S", "U", "V", "W"), "insolvency-proceedings"),
-    VOLUNTARY_PROCEEDINGS(List.of("I"), "voluntary_proceedings"),
+    VOLUNTARY_ARRANGEMENT(List.of("I"), "voluntary-arrangement"),
     ADMINISTRATION(List.of("M", "T"), "administration"),
     REMOVED(List.of("AD"), "removed"),
     REGISTERED(List.of("AC"), "registered");

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/enums/CompanyStatusTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/enums/CompanyStatusTest.java
@@ -99,10 +99,10 @@ class CompanyStatusTest {
                         )
                 ),
                 Arguments.of(
-                        Named.of("Test company status voluntary_proceedings",
+                        Named.of("Test company status voluntary-arrangement",
                                 CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
                                         .withDeltaCompanyStatusList(List.of("I"))
-                                        .withCompanyStatus("voluntary_proceedings")
+                                        .withCompanyStatus("voluntary-arrangement")
                                         .build()
                         )
                 ),


### PR DESCRIPTION
This PR fixes a bug involving company status enums. If the `status` field on the officer delta had the value of `I`, it would would transform the status to an invalid company status enum. This originally was the enum `voluntary_proceedings` when it should be `voluntary-arrangement`.

This bug would prevent appointments, with the status of `I` on their delta, from being persisted to the `delta_appointments` collection.

Tested locally.

[DSND-2017](https://companieshouse.atlassian.net/browse/DSND-2017)

[DSND-2017]: https://companieshouse.atlassian.net/browse/DSND-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ