### PR TITLE
DSND-2017: Refactor company status unit tests

### DIFF
--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/enums/CompanyStatusTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/model/enums/CompanyStatusTest.java
@@ -1,177 +1,51 @@
 package uk.gov.companieshouse.officer.delta.processor.model.enums;
 
-import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.CsvSource;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class CompanyStatusTest {
 
     @ParameterizedTest
-    @MethodSource("companyStatusScenarios")
-    void successfullyMapCompanyStatusEnum(CompanyStatusTestArgument argument) {
-        // given
-
-        // when
-        List<String> companyStatusList = new ArrayList<>();
-        for (String statusKey : argument.getDeltaCompanyStatusKeys()) {
-            companyStatusList.add(CompanyStatus.statusFromKey(statusKey));
-        }
-
-        // then
-        assertFalse(companyStatusList.isEmpty());
-        assertTrue(companyStatusList.stream().allMatch(
-                        companyStatus -> Objects.equals(companyStatus, argument.getExpectedCompanyStatus())));
-    }
-
-    private static Stream<Arguments> companyStatusScenarios() {
-        return Stream.of(
-                Arguments.of(
-                        Named.of("Test company status active",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("0", "5", "Q", "AA", "AB"))
-                                        .withCompanyStatus("active")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status dissolved",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("1", "R"))
-                                        .withCompanyStatus("dissolved")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status converted-closed",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("4", "7", "X", "Z"))
-                                        .withCompanyStatus("converted-closed")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status liquidation",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("2"))
-                                        .withCompanyStatus("liquidation")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status receivership",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("3", "A", "F", "G"))
-                                        .withCompanyStatus("receivership")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status open",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("8"))
-                                        .withCompanyStatus("open")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status closed",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("9"))
-                                        .withCompanyStatus("closed")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status insolvency-proceedings",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("C", "E", "H", "J", "K", "L", "N", "O", "P", "S", "U", "V", "W"))
-                                        .withCompanyStatus("insolvency-proceedings")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status voluntary-arrangement",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("I"))
-                                        .withCompanyStatus("voluntary-arrangement")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status administration",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("M", "T"))
-                                        .withCompanyStatus("administration")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status removed",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("AD"))
-                                        .withCompanyStatus("removed")
-                                        .build()
-                        )
-                ),
-                Arguments.of(
-                        Named.of("Test company status registered",
-                                CompanyStatusTestArgument.CompanyStatusTestArgumentBuilder()
-                                        .withDeltaCompanyStatusList(List.of("AC"))
-                                        .withCompanyStatus("registered")
-                                        .build()
-                        )
-                )
-        );
-    }
-
-    private static class CompanyStatusTestArgument {
-        private final List<String> deltaCompanyStatusKeys;
-        private final String expectedCompanyStatus;
-
-        private CompanyStatusTestArgument(List<String> deltaCompanyStatusKeys, String expectedCompanyStatus) {
-            this.deltaCompanyStatusKeys = deltaCompanyStatusKeys;
-            this.expectedCompanyStatus = expectedCompanyStatus;
-        }
-
-
-        private static CompanyStatusTestArgumentBuilder CompanyStatusTestArgumentBuilder() {
-            return new CompanyStatusTestArgumentBuilder();
-        }
-
-        public List<String> getDeltaCompanyStatusKeys() {
-            return deltaCompanyStatusKeys;
-        }
-
-        public String getExpectedCompanyStatus() {
-            return expectedCompanyStatus;
-        }
-
-        private static class CompanyStatusTestArgumentBuilder {
-            private List<String> deltaCompanyStatusList;
-            private String companyStatus;
-
-            public CompanyStatusTestArgumentBuilder withDeltaCompanyStatusList(List<String> statusList) {
-                this.deltaCompanyStatusList = statusList;
-                return this;
-            }
-
-            public CompanyStatusTestArgumentBuilder withCompanyStatus(String status) {
-                this.companyStatus = status;
-                return this;
-            }
-
-            public CompanyStatusTestArgument build() {
-                return new CompanyStatusTestArgument(this.deltaCompanyStatusList, this.companyStatus);
-            }
-        }
+    @CsvSource({
+            "0  , active",
+            "1  , dissolved",
+            "2  , liquidation",
+            "3  , receivership",
+            "4  , converted-closed",
+            "5  , active",
+            "7  , converted-closed",
+            "8  , open",
+            "9  , closed",
+            "A  , receivership",
+            "C  , insolvency-proceedings",
+            "E  , insolvency-proceedings",
+            "F  , receivership",
+            "G  , receivership",
+            "H  , insolvency-proceedings",
+            "I  , voluntary-arrangement",
+            "J  , insolvency-proceedings",
+            "K  , insolvency-proceedings",
+            "L  , insolvency-proceedings",
+            "M  , administration",
+            "N  , insolvency-proceedings",
+            "O  , insolvency-proceedings",
+            "P  , insolvency-proceedings",
+            "Q  , active",
+            "R  , dissolved",
+            "S  , insolvency-proceedings",
+            "T  , administration",
+            "U  , insolvency-proceedings",
+            "V  , insolvency-proceedings",
+            "W  , insolvency-proceedings",
+            "X  , converted-closed",
+            "Z  , converted-closed",
+            "AA  , active",
+            "AB  , active",
+            "AC  , registered",
+            "AD  , removed" })
+    void successfullyTransformCompanyStatus(String sourceStatus, String targetStatus) {
+        assertEquals(targetStatus, CompanyStatus.statusFromKey(sourceStatus));
     }
 }


### PR DESCRIPTION
This PR refactors the company status unit tests. The test data used is copied and pasted from chs-backend which means we have more reliable test data.

Enums: https://github.com/companieshouse/chs-backend/blob/4fea32dffa48b5780a96ba9dd899e672576d92c9/mappings/company_profile_enums.yaml#L58

[DSND-2017](https://companieshouse.atlassian.net/browse/DSND-2017)

[DSND-2017]: https://companieshouse.atlassian.net/browse/DSND-2017?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ