### PR TITLE
DSND-2062 Remove empty objects during transformation

### DIFF
--- a/src/itest/resources/data/corporate_managing_officer_delta_out.json
+++ b/src/itest/resources/data/corporate_managing_officer_delta_out.json
@@ -69,11 +69,7 @@
       "responsibilities" : "string",
       "former_names":null
     },
-    "sensitive_data":{
-      "usual_residential_address":null,
-      "residential_address_same_as_service_address":null,
-      "date_of_birth":null
-    },
+    "sensitive_data": null,
     "internal_id":"0025987375",
     "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
     "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",

--- a/src/itest/resources/data/corporate_non_corp_kind_officer_delta_out.json
+++ b/src/itest/resources/data/corporate_non_corp_kind_officer_delta_out.json
@@ -57,11 +57,7 @@
       "responsibilities":null,
       "former_names":null
     },
-    "sensitive_data":{
-      "usual_residential_address":null,
-      "residential_address_same_as_service_address":null,
-      "date_of_birth":null
-    },
+    "sensitive_data": null,
     "internal_id":"9001808864",
     "appointment_id":"ODxi2KP6LfSvwes9xY0O86YliyM",
     "officer_id":"gkfq1cddT1bYG4l0NfBY1ExfEOc",

--- a/src/itest/resources/data/corporate_officer_delta_out.json
+++ b/src/itest/resources/data/corporate_officer_delta_out.json
@@ -57,11 +57,7 @@
       "responsibilities":null,
       "former_names":null
     },
-    "sensitive_data":{
-      "usual_residential_address":null,
-      "residential_address_same_as_service_address":null,
-      "date_of_birth":null
-    },
+    "sensitive_data": null,
     "internal_id":"0025987375",
     "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
     "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",

--- a/src/itest/resources/data/corporate_other_corporate_body_officer_delta_out.json
+++ b/src/itest/resources/data/corporate_other_corporate_body_officer_delta_out.json
@@ -57,11 +57,7 @@
       "responsibilities":null,
       "former_names":null
     },
-    "sensitive_data":{
-      "usual_residential_address":null,
-      "residential_address_same_as_service_address":null,
-      "date_of_birth":null
-    },
+    "sensitive_data": null,
     "internal_id":"0025987375",
     "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
     "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",

--- a/src/itest/resources/data/corporate_roe_managing_officer_delta_out.json
+++ b/src/itest/resources/data/corporate_roe_managing_officer_delta_out.json
@@ -69,11 +69,7 @@
       "responsibilities" : "string",
       "former_names":null
     },
-    "sensitive_data":{
-      "usual_residential_address":null,
-      "residential_address_same_as_service_address":null,
-      "date_of_birth":null
-    },
+    "sensitive_data": null,
     "internal_id":"0025987375",
     "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
     "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",

--- a/src/itest/resources/data/pre_1992_corporate_officer_delta_out.json
+++ b/src/itest/resources/data/pre_1992_corporate_officer_delta_out.json
@@ -57,11 +57,7 @@
       "responsibilities":null,
       "former_names":null
     },
-    "sensitive_data":{
-      "usual_residential_address":null,
-      "residential_address_same_as_service_address":null,
-      "date_of_birth":null
-    },
+    "sensitive_data": null,
     "internal_id":"0025987375",
     "appointment_id":"EcEKO1YhIKexb0cSDZsn_OHsFw4",
     "officer_id":"r4Aq2-D3appznoESN24MtsLovfo",

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/Transformative.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/Transformative.java
@@ -1,7 +1,5 @@
 package uk.gov.companieshouse.officer.delta.processor.tranformer;
 
-import java.util.Objects;
-import org.apache.commons.lang3.ObjectUtils;
 import uk.gov.companieshouse.officer.delta.processor.exception.NonRetryableErrorException;
 
 import java.util.ArrayList;

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/Transformative.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/tranformer/Transformative.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.officer.delta.processor.tranformer;
 
+import java.util.Objects;
+import org.apache.commons.lang3.ObjectUtils;
 import uk.gov.companieshouse.officer.delta.processor.exception.NonRetryableErrorException;
 
 import java.util.ArrayList;
@@ -36,7 +38,11 @@ public interface Transformative<S, T> {
     T factory();
 
     default T transform(S source) throws NonRetryableErrorException {
-        return transform(source, factory());
+        T target = transform(source, factory());
+        if (target.equals(factory())) {
+            target = null;
+        }
+        return target;
     }
 
     T transform(S source, T output) throws NonRetryableErrorException;

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransformTest.java
@@ -118,8 +118,10 @@ class SensitiveOfficerTransformTest {
 
         if (RolesWithDateOfBirth.includes(officerRole)) {
             assertThat(outputOfficer.getDateOfBirth(), is(notNullValue()));
-        } else {
+        } else if (RolesWithResidentialAddress.includes(officerRole)) {
             assertThat(outputOfficer.getDateOfBirth(), is(nullValue()));
+        } else {
+            assertThat(outputOfficer, is(nullValue()));
         }
     }
 
@@ -158,8 +160,7 @@ class SensitiveOfficerTransformTest {
             assertThat(outputOfficer.getUsualResidentialAddress(), is(notNullValue()));
             assertThat(outputOfficer.getResidentialAddressSameAsServiceAddress(), is(true));
         } else {
-            assertThat(outputOfficer.getUsualResidentialAddress(), is(nullValue()));
-            assertThat(outputOfficer.getResidentialAddressSameAsServiceAddress(), is(nullValue()));
+            assertThat(outputOfficer, is(nullValue()));
         }
     }
 

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/tranformer/SensitiveOfficerTransformTest.java
@@ -76,7 +76,7 @@ class SensitiveOfficerTransformTest {
         officer.setAdditionalProperty("resignation_date", VALID_DATE);
         officer.setDateOfBirth(INVALID_DATE);
         officer.setOfficerRole(KIND_OF_OFFICER_ROLE_WITH_DOB);
-        verifyProcessingError(officerAPI, officer, "dateOfBirth: date/time pattern not matched: [yyyyMMdd]");
+        verifyProcessingError(officerAPI, officer);
     }
 
     @Test
@@ -164,12 +164,11 @@ class SensitiveOfficerTransformTest {
         }
     }
 
-    private void verifyProcessingError(final SensitiveData officerAPI, final OfficersItem officer,
-            final String expectedMessage) {
+    private void verifyProcessingError(final SensitiveData officerAPI, final OfficersItem officer) {
         final NonRetryableErrorException exception =
                 assertThrows(NonRetryableErrorException.class, () -> testTransform.transform(officer, officerAPI));
 
-        assertThat(exception.getMessage(), is(expectedMessage));
+        assertThat(exception.getMessage(), is("dateOfBirth: date/time pattern not matched: [yyyyMMdd]"));
     }
 
     private OfficersItem createOfficer(final AddressAPI address, final DeltaIdentification identification) {


### PR DESCRIPTION
* Removes any objects which contain only null fields before sending PUT request to company appointments API.

[DSND-2062](https://companieshouse.atlassian.net/browse/DSND-2062)

[DSND-2062]: https://companieshouse.atlassian.net/browse/DSND-2062?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ