### PR TITLE
DSND-3001: Retry more error types

### DIFF
--- a/src/itest/resources/features/RetriesAndErrors.feature
+++ b/src/itest/resources/features/RetriesAndErrors.feature
@@ -15,6 +15,11 @@ Feature: Retries and Errors
     When the consumer receives a message but the data api returns a 400
     Then the message should be moved to topic officer-delta-invalid
 
+  Scenario: Process message when the data api returns 409
+    Given the application is running
+    When the consumer receives a message but the data api returns a 409
+    Then the message should be moved to topic officer-delta-invalid
+
   Scenario: Process message when the data api returns 503
     Given the application is running
     When the consumer receives a message but the data api returns a 503

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumer.java
@@ -5,7 +5,10 @@ import org.springframework.kafka.annotation.KafkaListener;
 import org.springframework.kafka.annotation.RetryableTopic;
 import org.springframework.kafka.retrytopic.DltStrategy;
 import org.springframework.kafka.retrytopic.FixedDelayStrategy;
+import org.springframework.kafka.retrytopic.RetryTopicHeaders;
+import org.springframework.kafka.support.KafkaHeaders;
 import org.springframework.messaging.Message;
+import org.springframework.messaging.handler.annotation.Header;
 import org.springframework.retry.annotation.Backoff;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.delta.ChsDelta;
@@ -42,7 +45,11 @@ public class DeltaConsumer {
     @KafkaListener(topics = "${officer.delta.processor.topic}",
             groupId = "${kafka.odp.group.name}",
             containerFactory = "listenerContainerFactory")
-    public void receiveMainMessages(Message<ChsDelta> message) {
+    public void receiveMainMessages(Message<ChsDelta> message,
+                                    @Header(name = RetryTopicHeaders.DEFAULT_HEADER_ATTEMPTS, required = false) Integer attempt,
+                                    @Header(KafkaHeaders.RECEIVED_TOPIC) String topic,
+                                    @Header(KafkaHeaders.RECEIVED_PARTITION_ID) Integer partition,
+                                    @Header(KafkaHeaders.OFFSET) Long offset) {
         var chsDelta = message.getPayload();
 
         if (Boolean.TRUE.equals(chsDelta.getIsDelete())) {

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/StructuredLoggingKafkaListenerAspect.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/StructuredLoggingKafkaListenerAspect.java
@@ -1,43 +1,53 @@
 package uk.gov.companieshouse.officer.delta.processor.logging;
 
+import static uk.gov.companieshouse.officer.delta.processor.OfficerDeltaProcessorApplication.NAMESPACE;
+
 import java.util.Arrays;
 import java.util.Optional;
 import java.util.UUID;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-import uk.gov.companieshouse.officer.delta.processor.OfficerDeltaProcessorApplication;
 import uk.gov.companieshouse.officer.delta.processor.exception.RetryableErrorException;
 
 @Component
 @Aspect
 class StructuredLoggingKafkaListenerAspect {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(
-            OfficerDeltaProcessorApplication.NAMESPACE);
+    private static final Logger LOGGER = LoggerFactory.getLogger(NAMESPACE);
 
     private static final String LOG_MESSAGE_RECEIVED = "Processing delta";
     private static final String LOG_MESSAGE_PROCESSED = "Processed delta";
     private static final String EXCEPTION_MESSAGE = "%s exception thrown: %s";
 
+    private final int maxAttempts;
+
+    public StructuredLoggingKafkaListenerAspect(@Value("${officer.delta.processor.attempts}") int maxAttempts) {
+        this.maxAttempts = maxAttempts;
+    }
+
     @Around("@annotation(org.springframework.kafka.annotation.KafkaListener)")
     public Object manageStructuredLogging(ProceedingJoinPoint joinPoint)
         throws Throwable {
 
+        int retryCount = 0;
         try {
             Message<?> message = (Message<?>) joinPoint.getArgs()[0];
+            retryCount = Optional.ofNullable((Integer) joinPoint.getArgs()[1]).orElse(1) - 1;
             DataMapHolder.initialise(extractContextId(message.getPayload())
                     .orElse(UUID.randomUUID().toString()));
 
             DataMapHolder.get()
-                    .topic((String) message.getHeaders().get("kafka_receivedTopic"))
-                    .partition((Integer) message.getHeaders().get("kafka_receivedPartitionId"))
-                    .offset((Long)message.getHeaders().get("kafka_offset"));
+                    .retryCount(retryCount)
+                    .topic((String) joinPoint.getArgs()[2])
+                    .partition((Integer) joinPoint.getArgs()[3])
+                    .offset((Long) joinPoint.getArgs()[4]);
 
             LOGGER.info(LOG_MESSAGE_RECEIVED, DataMapHolder.getLogMap());
 
@@ -47,9 +57,14 @@ class StructuredLoggingKafkaListenerAspect {
 
             return result;
         } catch (RetryableErrorException ex) {
-            LOGGER.info(String.format(EXCEPTION_MESSAGE,
-                            ex.getClass().getSimpleName(), Arrays.toString(ex.getStackTrace())),
-                    DataMapHolder.getLogMap());
+            // maxAttempts includes first attempt which is not a retry
+            if (retryCount >= maxAttempts -1){
+                LOGGER.error("Max retry attempts reached", ex, DataMapHolder.getLogMap());
+            } else {
+                LOGGER.info(String.format(EXCEPTION_MESSAGE,
+                                ex.getClass().getSimpleName(), Arrays.toString(ex.getStackTrace())),
+                        DataMapHolder.getLogMap());
+            }
             throw ex;
         } catch (Exception ex) {
             LOGGER.errorContext(ex.getMessage(), ex, DataMapHolder.getLogMap());

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
@@ -1,5 +1,8 @@
 package uk.gov.companieshouse.officer.delta.processor.processor;
 
+import static uk.gov.companieshouse.officer.delta.processor.OfficerDeltaProcessorApplication.NAMESPACE;
+import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseOffsetDateTime;
+
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -9,7 +12,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.server.ResponseStatusException;
 import uk.gov.companieshouse.api.appointment.FullRecordCompanyOfficerApi;
 import uk.gov.companieshouse.api.delta.OfficerDeleteDelta;
-import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.delta.ChsDelta;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -21,13 +23,9 @@ import uk.gov.companieshouse.officer.delta.processor.model.OfficersItem;
 import uk.gov.companieshouse.officer.delta.processor.service.api.ApiClientService;
 import uk.gov.companieshouse.officer.delta.processor.tranformer.AppointmentTransform;
 import uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils;
-
 import java.util.List;
 import java.util.Map;
 import java.util.regex.Pattern;
-
-import static uk.gov.companieshouse.officer.delta.processor.OfficerDeltaProcessorApplication.NAMESPACE;
-import static uk.gov.companieshouse.officer.delta.processor.tranformer.TransformerUtils.parseOffsetDateTime;
 
 
 @Component
@@ -67,11 +65,7 @@ public class DeltaProcessor implements Processor<ChsDelta> {
                         .getInternalData()
                         .setDeltaAt(parseOffsetDateTime("deltaAt", officers.getDeltaAt()));
 
-                ApiResponse<Void> response =
-                        apiClientService.putAppointment(logContext, officer.getCompanyNumber(), appointmentAPI);
-
-                handleResponse(null, HttpStatus.valueOf(response.getStatusCode()), logContext,
-                        "Response from sending officer data");
+                apiClientService.putAppointment(logContext, officer.getCompanyNumber(), appointmentAPI);
             }
         }
         catch (JsonProcessingException e) {
@@ -131,13 +125,10 @@ public class DeltaProcessor implements Processor<ChsDelta> {
             logger.errorContext(logContext, msg, ex, logMap);
             throw new NonRetryableErrorException(msg, ex);
         }
-        else if (httpStatus.is4xxClientError() || httpStatus.is5xxServerError()) {
+        else {
             // any other client or server status is retryable
             logger.infoContext(logContext, msg + ", retry", logMap);
             throw new RetryableErrorException(msg, ex);
-        }
-        else {
-            logger.debugContext(logContext, msg, logMap);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/BaseApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/BaseApiClientServiceImpl.java
@@ -48,9 +48,9 @@ public abstract class BaseApiClientServiceImpl {
             logMap.put("status", ex.getStatusCode());
             if (ex.getStatusCode() == HttpStatus.BAD_REQUEST.value() || ex.getStatusCode() == HttpStatus.CONFLICT.value()) {
                 logger.errorContext(logContext, SDK_EXCEPTION, ex, logMap);
+            } else {
+                logger.infoContext(logContext, SDK_EXCEPTION, logMap);
             }
-            logger.infoContext(logContext, SDK_EXCEPTION, logMap);
-
             throw new ResponseStatusException(HttpStatus.valueOf(ex.getStatusCode()),
                     ex.getStatusMessage(), ex);
         }

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/BaseApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/BaseApiClientServiceImpl.java
@@ -37,7 +37,7 @@ public abstract class BaseApiClientServiceImpl {
 
         }
         catch (URIValidationException ex) {
-            logger.errorContext(logContext, "SDK exception", ex, buildLogMap(operationName, uri));
+            logger.infoContext(logContext, "SDK exception", buildLogMap(operationName, uri));
 
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
         } catch (ApiErrorResponseException ex) {

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/BaseApiClientServiceImpl.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/BaseApiClientServiceImpl.java
@@ -12,6 +12,9 @@ import java.util.Map;
 import uk.gov.companieshouse.officer.delta.processor.logging.DataMapHolder;
 
 public abstract class BaseApiClientServiceImpl {
+
+    private static final String SDK_EXCEPTION = "SDK exception";
+    
     protected Logger logger;
 
     protected BaseApiClientServiceImpl(final Logger logger) {
@@ -37,13 +40,16 @@ public abstract class BaseApiClientServiceImpl {
 
         }
         catch (URIValidationException ex) {
-            logger.infoContext(logContext, "SDK exception", buildLogMap(operationName, uri));
+            logger.infoContext(logContext, SDK_EXCEPTION, buildLogMap(operationName, uri));
 
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
         } catch (ApiErrorResponseException ex) {
             Map<String, Object> logMap = buildLogMap(operationName, uri);
             logMap.put("status", ex.getStatusCode());
-            logger.errorContext(logContext, "SDK exception", ex, logMap);
+            if (ex.getStatusCode() == HttpStatus.BAD_REQUEST.value() || ex.getStatusCode() == HttpStatus.CONFLICT.value()) {
+                logger.errorContext(logContext, SDK_EXCEPTION, ex, logMap);
+            }
+            logger.infoContext(logContext, SDK_EXCEPTION, logMap);
 
             throw new ResponseStatusException(HttpStatus.valueOf(ex.getStatusCode()),
                     ex.getStatusMessage(), ex);

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/consumer/DeltaConsumerTest.java
@@ -32,7 +32,7 @@ class DeltaConsumerTest {
     @Test
     void When_consumer_receives_valid_payload_process_is_called() throws IOException {
         Message<ChsDelta> message = Util.createChsDeltaMessage("officer_delta_example.json", false);
-        consumer.receiveMainMessages(message);
+        consumer.receiveMainMessages(message,0, "officer-delta", 10, 1L);
 
         verify(processor).process(any());
     }
@@ -40,7 +40,7 @@ class DeltaConsumerTest {
     @Test
     void When_consumer_receives_valid_delete_payload_processDelete_is_called() throws IOException {
         Message<ChsDelta> message = Util.createChsDeltaMessage("officer_delete_delta.json", true);
-        consumer.receiveMainMessages(message);
+        consumer.receiveMainMessages(message, 0, "officer-delta", 10, 1L);
 
         verify(processor).processDelete(any());
     }
@@ -54,6 +54,6 @@ class DeltaConsumerTest {
                 .when(processor).process(brokenMessage);
 
         Assert.assertThrows(Exception.class, ()->consumer
-                .receiveMainMessages(message));
+                .receiveMainMessages(message, 0, "officer-delta", 10, 1L));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
@@ -175,7 +175,7 @@ class DeltaProcessorTest {
     }
 
     private static Stream<HttpStatus> provideRetryableStatuses() {
-        return EnumSet.allOf(HttpStatus.class).stream().filter(s -> s.value() > HttpStatus.BAD_REQUEST.value());
+        return EnumSet.allOf(HttpStatus.class).stream().filter(s -> s.value() > HttpStatus.BAD_REQUEST.value() && s.value() != HttpStatus.CONFLICT.value());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
@@ -175,7 +175,7 @@ class DeltaProcessorTest {
     }
 
     private static Stream<HttpStatus> provideRetryableStatuses() {
-        return EnumSet.allOf(HttpStatus.class).stream().filter(s -> s.value() > HttpStatus.BAD_REQUEST.value() && s.value() != HttpStatus.CONFLICT.value());
+        return EnumSet.allOf(HttpStatus.class).stream().filter(s -> s.value() != HttpStatus.BAD_REQUEST.value() && s.value() != HttpStatus.CONFLICT.value());
     }
 
     @Test

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
@@ -156,10 +156,6 @@ class DeltaProcessorTest {
         inOrder.verifyNoMoreInteractions();
     }
 
-    private static Stream<HttpStatus> provideRetryableStatuses() {
-        return EnumSet.allOf(HttpStatus.class).stream().filter(s -> s.value() > HttpStatus.BAD_REQUEST.value());
-    }
-
     @ParameterizedTest
     @MethodSource("provideRetryableStatuses")
     void processWhenResponseStatusRetryable(final HttpStatus responseStatus) {
@@ -178,6 +174,10 @@ class DeltaProcessorTest {
 
     }
 
+    private static Stream<HttpStatus> provideRetryableStatuses() {
+        return EnumSet.allOf(HttpStatus.class).stream().filter(s -> s.value() > HttpStatus.BAD_REQUEST.value());
+    }
+
     @Test
     void processWhenClientServiceThrowsIllegalArgumentException() {
         final ChsDelta delta = new ChsDelta(json, 0, CONTEXT_ID, false);
@@ -192,10 +192,6 @@ class DeltaProcessorTest {
 
         inOrder.verify(apiClientService).putAppointment(CONTEXT_ID, expectedNumber, expectedAppointment);
         inOrder.verifyNoMoreInteractions();
-    }
-
-    private static Stream<HttpStatus> provideNonRetryableStatuses() {
-        return Stream.of(HttpStatus.BAD_REQUEST);
     }
 
     @ParameterizedTest
@@ -213,6 +209,10 @@ class DeltaProcessorTest {
 
         inOrder.verify(apiClientService).putAppointment(CONTEXT_ID, expectedNumber, expectedAppointment);
         inOrder.verifyNoMoreInteractions();
+    }
+
+    private static Stream<HttpStatus> provideNonRetryableStatuses() {
+        return Stream.of(HttpStatus.BAD_REQUEST, HttpStatus.CONFLICT);
     }
 
     @Test


### PR DESCRIPTION
* All error types apart from data malformation, 400 and 409 are retried.
* StructuredLoggingKafkaListenerAspect made the same as in filing history consumer with retry attempts included.

Locally Tested

[DSND-3001](https://companieshouse.atlassian.net/browse/DSND-3001)

[DSND-3001]: https://companieshouse.atlassian.net/browse/DSND-3001?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ