### PR TITLE
DSND-3109: Add delta at to delete test data

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>uk.gov.companieshouse</groupId>
 		<artifactId>companies-house-parent</artifactId>
-		<version>1.3.1</version>
+		<version>2.1.6</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<artifactId>officer-delta-processor</artifactId>
@@ -20,7 +20,7 @@
 
 		<ch-kafka.version>1.4.8</ch-kafka.version>
 		<kafka-models.version>1.0.31</kafka-models.version>
-		<private.sdk.version>2.0.425</private.sdk.version>
+		<private.sdk.version>2.0.443</private.sdk.version>
 		<spring.boot.version>2.7.14</spring.boot.version>
 
 		<!-- Logging -->

--- a/src/itest/resources/data/delete_delta.json
+++ b/src/itest/resources/data/delete_delta.json
@@ -2,5 +2,6 @@
   "internal_id": "3102598777",
   "company_number": "09876543",
   "officer_id": "3001237435",
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "20230724093435661593"
 }

--- a/src/test/resources/officer_delete_delta.json
+++ b/src/test/resources/officer_delete_delta.json
@@ -2,5 +2,6 @@
   "internal_id": "3102598777",
   "company_number": "09876543",
   "officer_id": "3001237435",
-  "action": "DELETE"
+  "action": "DELETE",
+  "delta_at": "20230724093435661593"
 }


### PR DESCRIPTION
This PR updates the tests to ensure the consumer can handle a delta_at field on an incoming delete delta.

[DSND-3109](https://companieshouse.atlassian.net/browse/DSND-3109)

[DSND-3109]: https://companieshouse.atlassian.net/browse/DSND-3109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ