### PR TITLE
DSND-3111: Implements a delete delta with a delta_at check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,7 +20,7 @@
 
 		<ch-kafka.version>1.4.8</ch-kafka.version>
 		<kafka-models.version>1.0.31</kafka-models.version>
-		<private.sdk.version>2.0.444</private.sdk.version>
+		<private.sdk.version>2.0.449</private.sdk.version>
 		<spring.boot.version>2.7.14</spring.boot.version>
 
 		<!-- Logging -->
@@ -41,6 +41,7 @@
 		<!-- Maven -->
 		<maven.compiler.source>11</maven.compiler.source>
 		<maven.compiler.target>11</maven.compiler.target>
+		<jib-maven-plugin.version>3.4.2</jib-maven-plugin.version>
 
 		<!-- Sonar dependency -->
 		<sonar.projectKey>uk.gov.companieshouse:officer-delta-processor</sonar.projectKey>
@@ -424,8 +425,14 @@
 			<plugin>
 				<groupId>com.google.cloud.tools</groupId>
 				<artifactId>jib-maven-plugin</artifactId>
-				<version>3.3.2</version>
+				<version>${jib-maven-plugin.version}</version>
+				<configuration>
+					<to>
+						<image>169942020521.dkr.ecr.eu-west-2.amazonaws.com/local/officer-delta-processor:latest</image>
+					</to>
+				</configuration>
 			</plugin>
+
 		</plugins>
 	</build>
 </project>

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/steps/CommonSteps.java
@@ -38,7 +38,7 @@ public class CommonSteps {
 
     private static final String DELETE_DELTA_URI =
             "/company/09876543/appointments/N-YqKNwdT_HvetusfTJ0H0jAQbA/full_record/delete";
-    private static final String DELETE_DELTA_AT = "20220925171003950844";
+    private static final String DELETE_DELTA_AT = "20230724093435661593";
     private static final String X_DELTA_AT = "X-DELTA-AT";
 
     @Value("${officer.delta.processor.topic}")

--- a/src/itest/java/uk/gov/companieshouse/officer/delta/processor/steps/CommonSteps.java
+++ b/src/itest/java/uk/gov/companieshouse/officer/delta/processor/steps/CommonSteps.java
@@ -25,6 +25,7 @@ import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
 import static com.github.tomakehurst.wiremock.client.WireMock.configureFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.delete;
 import static com.github.tomakehurst.wiremock.client.WireMock.deleteRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.put;
 import static com.github.tomakehurst.wiremock.client.WireMock.requestMadeFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
@@ -34,6 +35,11 @@ import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class CommonSteps {
+
+    private static final String DELETE_DELTA_URI =
+            "/company/09876543/appointments/N-YqKNwdT_HvetusfTJ0H0jAQbA/full_record/delete";
+    private static final String DELETE_DELTA_AT = "20220925171003950844";
+    private static final String X_DELTA_AT = "X-DELTA-AT";
 
     @Value("${officer.delta.processor.topic}")
     private String mainTopic;
@@ -146,8 +152,8 @@ public class CommonSteps {
 
     @Then("a DELETE request is sent to the appointments api with the encoded Id and company number")
     public void deleteRequestIsSent() {
-        verify(1, deleteRequestedFor(urlMatching(
-                "/company/09876543/appointments/N-YqKNwdT_HvetusfTJ0H0jAQbA/full_record/delete")));
+        verify(1, deleteRequestedFor(urlMatching(DELETE_DELTA_URI))
+                .withHeader(X_DELTA_AT, equalTo(DELETE_DELTA_AT)));
     }
 
     @After
@@ -172,7 +178,8 @@ public class CommonSteps {
     }
 
     private void stubDeleteOfficer(int responseCode) {
-        stubFor(delete(urlEqualTo("/company/09876543/appointments/N-YqKNwdT_HvetusfTJ0H0jAQbA/full_record/delete"))
+        stubFor(delete(urlEqualTo(DELETE_DELTA_URI))
+                .withHeader(X_DELTA_AT, equalTo(DELETE_DELTA_AT))
                 .willReturn(aResponse().withStatus(responseCode)));
     }
 

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessor.java
@@ -99,14 +99,14 @@ public class DeltaProcessor implements Processor<ChsDelta> {
         try {
             officersDelete = objectMapper.readValue(chsDelta.getData(),
                     OfficerDeleteDelta.class);
-        final String companyNumber = officersDelete.getCompanyNumber();
-        DataMapHolder.get()
-                .companyNumber(companyNumber)
-                .officerId(officersDelete.getOfficerId())
-                .internalId(officersDelete.getInternalId());
+            final String companyNumber = officersDelete.getCompanyNumber();
+            DataMapHolder.get()
+                    .companyNumber(companyNumber)
+                    .officerId(officersDelete.getOfficerId())
+                    .internalId(officersDelete.getInternalId());
 
-        final String internalId = TransformerUtils.encode(officersDelete.getInternalId());
-            apiClientService.deleteAppointment(logContext, internalId, companyNumber);
+            final String internalId = TransformerUtils.encode(officersDelete.getInternalId());
+            apiClientService.deleteAppointment(logContext, internalId, companyNumber, officersDelete.getDeltaAt());
         } catch (ResponseStatusException e) {
             handleResponse(e, e.getStatus(), logContext, "Sending officer delete failed");
         } catch (Exception ex) {

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientService.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientService.java
@@ -31,5 +31,6 @@ public interface ApiClientService {
      * @param companyNumber the company number
      * @return the api response
      */
-    ApiResponse<Void> deleteAppointment(final String logContext, final String internalId,final String companyNumber);
+    ApiResponse<Void> deleteAppointment(final String logContext, final String internalId,final String companyNumber,
+            String deltaAt);
 }

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
@@ -67,6 +67,7 @@ import java.util.stream.Stream;
 @ExtendWith(MockitoExtension.class)
 class DeltaProcessorTest {
     private static final String CONTEXT_ID = "context_id";
+    private static final String DELTA_AT = "20140925171003950844";
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule());
@@ -225,11 +226,12 @@ class DeltaProcessorTest {
         final String expectedInternalId = TransformerUtils.encode(expectedDelete.getInternalId());
         final ApiResponse<Void> response = new ApiResponse<>(HttpStatus.OK.value(), null, null);
 
-        when(apiClientService.deleteAppointment(CONTEXT_ID, expectedInternalId, expectedNumber)).thenReturn(response);
+        when(apiClientService.deleteAppointment(CONTEXT_ID, expectedInternalId, expectedNumber, DELTA_AT))
+                .thenReturn(response);
 
         testProcessor.processDelete(delta);
 
-        verify(apiClientService).deleteAppointment(CONTEXT_ID, expectedInternalId, expectedNumber);
+        verify(apiClientService).deleteAppointment(CONTEXT_ID, expectedInternalId, expectedNumber, DELTA_AT);
         verifyNoMoreInteractions(apiClientService);
         assertThat(capture.getOut()).doesNotContain("event: error");
     }

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/processor/DeltaProcessorTest.java
@@ -67,7 +67,7 @@ import java.util.stream.Stream;
 @ExtendWith(MockitoExtension.class)
 class DeltaProcessorTest {
     private static final String CONTEXT_ID = "context_id";
-    private static final String DELTA_AT = "20140925171003950844";
+    private static final String DELTA_AT = "20230724093435661593";
 
     private static final ObjectMapper objectMapper = new ObjectMapper()
             .registerModule(new JavaTimeModule());

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImplTest.java
@@ -26,6 +26,8 @@ import static org.mockito.Mockito.verify;
 @ExtendWith(MockitoExtension.class)
 class ApiClientServiceImplTest {
 
+    private static final String DELTA_AT = "20220925171003950844";
+
     @Mock
     Logger logger;
 
@@ -68,7 +70,7 @@ class ApiClientServiceImplTest {
                 any(PrivateOfficerDelete.class));
 
         ApiResponse<Void> response = apiClientServiceSpy.deleteAppointment("context_id",
-                "N-YqKNwdT_HvetusfTJ0H0jAQbA", "09876543");
+                "N-YqKNwdT_HvetusfTJ0H0jAQbA", "09876543", DELTA_AT);
         verify(apiClientServiceSpy).executeOp(anyString(), eq("deleteOfficer"),
                 eq("/company/09876543/appointments/N-YqKNwdT_HvetusfTJ0H0jAQbA/full_record/delete"),
                 any(PrivateOfficerDelete.class));

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/service/api/ApiClientServiceImplTest.java
@@ -1,8 +1,10 @@
 package uk.gov.companieshouse.officer.delta.processor.service.api;
 
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -77,7 +79,14 @@ class ApiClientServiceImplTest {
 
         assertThat(response).isEqualTo(expectedResponse);
     }
+
+    @Test
+    void shouldFailDeleteOfficerWhenMissingDeltaAt() {
+        ApiClientServiceImpl apiClientServiceSpy = Mockito.spy(apiClientService);
+
+        Executable executable = () ->  apiClientServiceSpy.deleteAppointment("context_id",
+                "N-YqKNwdT_HvetusfTJ0H0jAQbA", "09876543", null);
+
+        Assertions.assertThrows(IllegalArgumentException.class, executable, "delta_at null or empty");
+    }
 }
-
-
-


### PR DESCRIPTION
After updates to the private-api-sdk-java delete resource API, delete offices now include a `delta_at` check to stop stale deltas deleting new documents

[DSND-3111](https://companieshouse.atlassian.net/browse/DSND-3111)

[DSND-3111]: https://companieshouse.atlassian.net/browse/DSND-3111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ