### PR TITLE
seeing error in ECS logs saying to remove commons-logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -200,11 +200,23 @@
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>private-api-sdk-java</artifactId>
       <version>${private-sdk.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>uk.gov.companieshouse</groupId>
       <artifactId>api-sdk-manager-java-library</artifactId>
       <version>${api-sdk-manager-java-library.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- CVE-2025-41242 and CVE-2025-48989 -->


### PR DESCRIPTION
Following last PR #131, I see this error in ECS logs:

<img width="1511" height="624" alt="Screenshot 2026-03-11 at 3 24 28 pm" src="https://github.com/user-attachments/assets/7c8626f1-0382-4800-83a1-0cb6225682e0" />

The commons-logging exclusions are done in other services eg https://github.com/companieshouse/psc-verification-api/blob/main/pom.xml#L117-L122

ASM-1635