### PR TITLE
Patch critical security flaws for ASM-2143

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,14 +25,12 @@
 
     <ch-kafka.version>3.0.8</ch-kafka.version>
     <kafka-models.version>3.0.29</kafka-models.version>
-    <private-sdk.version>4.0.476</private-sdk.version>
-    <spring.boot.version>3.5.11</spring.boot.version>
+    <private-sdk.version>4.0.494</private-sdk.version>
+    <spring.boot.version>3.5.14</spring.boot.version>
     <apache-avro.version>1.12.1</apache-avro.version>
-    <spring-core.version>6.2.16</spring-core.version>
-    <tomcat-embed-dependencies.version>10.1.52</tomcat-embed-dependencies.version>
 
     <!-- Logging -->
-    <structured-logging.version>3.0.51</structured-logging.version>
+    <structured-logging.version>3.0.54</structured-logging.version>
     <api-sdk-manager-java-library.version>3.0.16</api-sdk-manager-java-library.version>
 
     <!-- Test -->
@@ -46,7 +44,7 @@
     <maven-build-helper-plugin.version>3.6.1</maven-build-helper-plugin.version>
     <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     <awaitility.version>4.3.0</awaitility.version>
-    <opentelemetry-version>2.23.0</opentelemetry-version>
+    <opentelemetry-version>2.26.1</opentelemetry-version>
 
     <!-- Maven -->
     <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -98,19 +96,13 @@
         <type>pom</type>
         <scope>import</scope>
       </dependency>
-      <!-- Pinning version to address CVE-2024-29371 in 0.9.4 pulled transitively by spring-kafka-test:jar:3.3.12-->
+      <!-- Pinning for CVE-2026-33186 in grpc-api < 1.79.3 -->
       <dependency>
-        <groupId>org.bitbucket.b_c</groupId>
-        <artifactId>jose4j</artifactId>
-        <version>0.9.6</version>
-        <scope>compile</scope>
-      </dependency>
-      <!-- Pinning version to address CVE-2025-53103 in 1.12.2 pulled transitively by spring-kafka-test:jar:3.3.12-->
-      <dependency>
-        <groupId>org.junit.platform</groupId>
-        <artifactId>junit-platform-reporting</artifactId>
-        <version>1.14.3</version>
-        <scope>test</scope>
+        <groupId>io.grpc</groupId>
+        <artifactId>grpc-bom</artifactId>
+        <version>1.80.0</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -189,11 +181,11 @@
       </exclusions>
     </dependency>
 
-    <!-- Pinning version to address CVE-2025-68161(6.3) log4j-api pulled transitively-->
+    <!-- Pinning version to address CVE-2025-68161(6.3), CVE-2026-34478(6.9), CVE-2026-34480(6.9), CVE-2026-34481(6.3) log4j-api pulled transitively-->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.25.3</version>
+      <version>2.25.4</version>
     </dependency>
 
     <dependency>
@@ -217,28 +209,6 @@
           <artifactId>commons-logging</artifactId>
         </exclusion>
       </exclusions>
-    </dependency>
-
-    <!-- CVE-2025-41242 and CVE-2025-48989 -->
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>${spring-core.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-core</artifactId>
-      <version>${tomcat-embed-dependencies.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-websocket</artifactId>
-      <version>${tomcat-embed-dependencies.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-el</artifactId>
-      <version>${tomcat-embed-dependencies.version}</version>
     </dependency>
 
     <!-- Test -->
@@ -343,7 +313,7 @@
       </exclusions>
     </dependency>
     <!-- Pinning version to address CVE-2020-29582(5.3) in kotlin-stdlib:jar:1.9.25
-         pulled transitively by opentelemetry-spring-boot-starter:jar:2.23.0 -->
+         pulled transitively by opentelemetry-spring-boot-starter:jar:2.26.1 -->
     <dependency>
       <groupId>org.jetbrains.kotlin</groupId>
       <artifactId>kotlin-stdlib</artifactId>


### PR DESCRIPTION
Patch security flaws (severity in brackets, 9.0 - 10.0 = Critical)

- CVE-2026-33186(9.1)
- CVE-2026-5795(7.4)
- CVE-2026-5795(7.4)
- CVE-2026-33558(5.3)
- CVE-2026-34478(6.9)
- CVE-2026-34480(6.9)
- CVE-2026-34481(6.3)
- CVE-2026-22733(8.1)
- CVE-2026-22731(8.1)
- CVE-2026-22737(5.9)
- CVE-2026-32990(5.3)
- CVE-2026-34500(6.5)
- CVE-2026-34487(7.5)
- CVE-2026-29145(9.1)
- CVE-2026-29146(7.5)
- CVE-2026-34483(7.5)
- CVE-2026-24880(7.5)
- CVE-2026-29129(7.5)
- CVE-2026-25854(6.1)

Remove outdated security patches

Update some CH dependencies to latest

Update open-telemetry to latest

Resolves
ASM-2143

<img width="2077" height="1346" alt="Screenshot 2026-04-27 at 15 31 17" src="https://github.com/user-attachments/assets/62b4c769-3c0a-40e5-8a6f-b8d31af8bf46" />
<img width="2077" height="1346" alt="Screenshot 2026-04-27 at 15 31 43" src="https://github.com/user-attachments/assets/b48fcc1d-cb8c-4b84-ab83-d09926e15f62" />
<img width="2587" height="1521" alt="Screenshot 2026-04-27 at 15 32 38" src="https://github.com/user-attachments/assets/aa24dc5d-9d70-4f7d-a576-cce7e134e178" />



