### PR TITLE
LP-1911 Set principal office address for LP corporate partners

### DIFF
--- a/src/itest/resources/data/limited_partnership_general_partner_legal_entity_officer_delta_in.json
+++ b/src/itest/resources/data/limited_partnership_general_partner_legal_entity_officer_delta_in.json
@@ -35,7 +35,7 @@
         "identity_verified_on": "20241216",
         "preferred_name": "Preferred Name"
       },
-      "service_address": {
+      "principal_office_address": {
         "premise": "1",
         "address_line_1" : "1 Crown Way",
         "address_line_2" : "Pavement",
@@ -45,19 +45,6 @@
         "region" : "Cardiff",
         "postal_code" : "CF14 3UZ",
         "country": "United Kingdom"
-      },
-      "usual_residential_address": {
-        "premise": "URA",
-        "address_line_1": "ura_line1",
-        "address_line_2": "ura_line2",
-        "locality": "Cardiff",
-        "care_of_name": "ura_care_of",
-        "region": "ura_region",
-        "po_box": "ura_po",
-        "supplied_company_name": "ura_cname",
-        "country": "United Kingdom",
-        "postal_code": "CF2 1B6",
-        "usual_country_of_residence": "United Kingdom"
       }
     }
   ],

--- a/src/itest/resources/data/limited_partnership_general_partner_legal_entity_officer_delta_out.json
+++ b/src/itest/resources/data/limited_partnership_general_partner_legal_entity_officer_delta_out.json
@@ -4,7 +4,7 @@
     "company_status": "active",
     "data":{
       "person_number": "12345",
-      "service_address":{
+      "principal_office_address":{
         "address_line_1":"1 Crown Way",
         "address_line_2":"Pavement",
         "care_of" : "John Smith",
@@ -64,7 +64,7 @@
       "title":null,
       "company_number":"01777777",
       "contact_details":null,
-      "principal_office_address":null,
+      "service_address":null,
       "resigned_on":null,
       "responsibilities":null,
       "former_names":null

--- a/src/itest/resources/data/limited_partnership_limited_partner_invalid_capital_contribution_subtype_officer_delta_in.json
+++ b/src/itest/resources/data/limited_partnership_limited_partner_invalid_capital_contribution_subtype_officer_delta_in.json
@@ -35,7 +35,7 @@
         "identity_verified_on": "20241216",
         "preferred_name": "Preferred Name"
       },
-      "service_address": {
+      "principal_office_address": {
         "premise": "1",
         "address_line_1" : "1 Crown Way",
         "address_line_2" : "Pavement",
@@ -45,19 +45,6 @@
         "region" : "Cardiff",
         "postal_code" : "CF14 3UZ",
         "country": "United Kingdom"
-      },
-      "usual_residential_address": {
-        "premise": "URA",
-        "address_line_1": "ura_line1",
-        "address_line_2": "ura_line2",
-        "locality": "Cardiff",
-        "care_of_name": "ura_care_of",
-        "region": "ura_region",
-        "po_box": "ura_po",
-        "supplied_company_name": "ura_cname",
-        "country": "United Kingdom",
-        "postal_code": "CF2 1B6",
-        "usual_country_of_residence": "United Kingdom"
       },
       "contribution_currency_type": "USD",
       "contribution_currency_value": "67345.22",

--- a/src/itest/resources/data/limited_partnership_limited_partner_invalid_capital_contribution_subtype_officer_delta_out.json
+++ b/src/itest/resources/data/limited_partnership_limited_partner_invalid_capital_contribution_subtype_officer_delta_out.json
@@ -4,7 +4,7 @@
     "company_status": "active",
     "data":{
       "person_number": "12345",
-      "service_address":{
+      "principal_office_address":{
         "address_line_1":"1 Crown Way",
         "address_line_2":"Pavement",
         "care_of" : "John Smith",
@@ -64,7 +64,7 @@
       "title":null,
       "company_number":"01777777",
       "contact_details":null,
-      "principal_office_address":null,
+      "service_address":null,
       "resigned_on":null,
       "responsibilities":null,
       "former_names":null,

--- a/src/itest/resources/data/limited_partnership_limited_partner_legal_entity_officer_delta_in.json
+++ b/src/itest/resources/data/limited_partnership_limited_partner_legal_entity_officer_delta_in.json
@@ -35,7 +35,7 @@
         "identity_verified_on": "20241216",
         "preferred_name": "Preferred Name"
       },
-      "service_address": {
+      "principal_office_address": {
         "premise": "1",
         "address_line_1" : "1 Crown Way",
         "address_line_2" : "Pavement",
@@ -45,19 +45,6 @@
         "region" : "Cardiff",
         "postal_code" : "CF14 3UZ",
         "country": "United Kingdom"
-      },
-      "usual_residential_address": {
-        "premise": "URA",
-        "address_line_1": "ura_line1",
-        "address_line_2": "ura_line2",
-        "locality": "Cardiff",
-        "care_of_name": "ura_care_of",
-        "region": "ura_region",
-        "po_box": "ura_po",
-        "supplied_company_name": "ura_cname",
-        "country": "United Kingdom",
-        "postal_code": "CF2 1B6",
-        "usual_country_of_residence": "United Kingdom"
       },
       "contribution_currency_type": "USD",
       "contribution_currency_value": "67345.22",

--- a/src/itest/resources/data/limited_partnership_limited_partner_legal_entity_officer_delta_out.json
+++ b/src/itest/resources/data/limited_partnership_limited_partner_legal_entity_officer_delta_out.json
@@ -4,7 +4,7 @@
     "company_status": "active",
     "data":{
       "person_number": "12345",
-      "service_address":{
+      "principal_office_address":{
         "address_line_1":"1 Crown Way",
         "address_line_2":"Pavement",
         "care_of" : "John Smith",
@@ -64,7 +64,7 @@
       "title":null,
       "company_number":"01777777",
       "contact_details":null,
-      "principal_office_address":null,
+      "service_address":null,
       "resigned_on":null,
       "responsibilities":null,
       "former_names":null,

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/transformer/OfficerTransform.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/transformer/OfficerTransform.java
@@ -169,6 +169,10 @@ public class OfficerTransform implements Transformative<OfficersItem, Data> {
                     source.getContributionSubTypes().stream().map(contributionSubTypeTransform::transform).toList());
         }
 
+        if (OfficerRole.LPGENPARTCORP.getValue().equals(officerRole) || OfficerRole.LPLIMPARTCORP.getValue().equals(officerRole)) {
+            officer.setPrincipalOfficeAddress(principalOfficeAddressTransform.transform(source.getPrincipalOfficeAddress()));
+        }
+
         return officer;
     }
 

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/transformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/transformer/OfficerTransformTest.java
@@ -408,16 +408,17 @@ class OfficerTransformTest {
 
     @ParameterizedTest
     @EnumSource(value = OfficerRole.class, names = {"LPLIMPARTCORP", "LPGENPARTCORP"})
-    void testPrincipalOfficeAddressIsSetWhenCorporatePartnerIsTransformed(OfficerRole officerRole) throws NonRetryableErrorException {
+    void testCorrectAddressesAreSetWhenCorporatePartnerIsTransformed(OfficerRole officerRole) throws NonRetryableErrorException {
         Data officerAPI = testTransform.factory();
         OfficersItem officer = createOfficer(addressAPI, identification);
-        AddressAPI principalOfficeAddressAPI = new AddressAPI();
 
         officer.setKind(officerRole.name());
-        officer.setPrincipalOfficeAddress(principalOfficeAddressAPI);
-
         officer.setAppointmentDate(VALID_DATE);
         officer.setDateOfBirth(VALID_DATE);
+
+        officer.setServiceAddress(null);
+        AddressAPI principalOfficeAddressAPI = new AddressAPI();
+        officer.setPrincipalOfficeAddress(principalOfficeAddressAPI);
 
         when(identificationTransform.transform(identification)).thenReturn(identificationAPI);
         when(principalOfficeAddressTransform.transform(principalOfficeAddressAPI)).thenReturn(principalOfficeAddress);
@@ -425,6 +426,29 @@ class OfficerTransformTest {
         final Data result = testTransform.transform(officer, officerAPI);
 
         assertThat(result.getPrincipalOfficeAddress(), is(principalOfficeAddress));
+        assertThat(result.getServiceAddress(), is(nullValue()));
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = OfficerRole.class, names = {"LPLIMPART", "LPGENPART"})
+    void testCorrectAddressesAreSetWhenNaturalPersonPartnerIsTransformed(OfficerRole officerRole) throws NonRetryableErrorException {
+        Data officerAPI = testTransform.factory();
+        OfficersItem officer = createOfficer(addressAPI, identification);
+
+        officer.setKind(officerRole.name());
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+
+        AddressAPI principalOfficeAddressAPI = new AddressAPI();
+        officer.setPrincipalOfficeAddress(principalOfficeAddressAPI);
+
+        when(identificationTransform.transform(identification)).thenReturn(identificationAPI);
+        when(serviceAddressTransform.transform(addressAPI)).thenReturn(serviceAddress);
+
+        final Data result = testTransform.transform(officer, officerAPI);
+
+        assertThat(result.getPrincipalOfficeAddress(), is(nullValue()));
+        assertThat(result.getServiceAddress(), is(sameInstance(serviceAddress)));
     }
 
     private void verifyProcessingError(final Data data, final OfficersItem officer,

--- a/src/test/java/uk/gov/companieshouse/officer/delta/processor/transformer/OfficerTransformTest.java
+++ b/src/test/java/uk/gov/companieshouse/officer/delta/processor/transformer/OfficerTransformTest.java
@@ -406,6 +406,27 @@ class OfficerTransformTest {
         assertThat(testTransform.transform((OfficersItem) null), is(nullValue()));
     }
 
+    @ParameterizedTest
+    @EnumSource(value = OfficerRole.class, names = {"LPLIMPARTCORP", "LPGENPARTCORP"})
+    void testPrincipalOfficeAddressIsSetWhenCorporatePartnerIsTransformed(OfficerRole officerRole) throws NonRetryableErrorException {
+        Data officerAPI = testTransform.factory();
+        OfficersItem officer = createOfficer(addressAPI, identification);
+        AddressAPI principalOfficeAddressAPI = new AddressAPI();
+
+        officer.setKind(officerRole.name());
+        officer.setPrincipalOfficeAddress(principalOfficeAddressAPI);
+
+        officer.setAppointmentDate(VALID_DATE);
+        officer.setDateOfBirth(VALID_DATE);
+
+        when(identificationTransform.transform(identification)).thenReturn(identificationAPI);
+        when(principalOfficeAddressTransform.transform(principalOfficeAddressAPI)).thenReturn(principalOfficeAddress);
+
+        final Data result = testTransform.transform(officer, officerAPI);
+
+        assertThat(result.getPrincipalOfficeAddress(), is(principalOfficeAddress));
+    }
+
     private void verifyProcessingError(final Data data, final OfficersItem officer,
             final String expectedMessage) {
 


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1911

* POA is now set on an officer if role is a general or limited corporate partner
* Unit tests added for corporate and natural person partners to check addresses
* Integration test resources also update to reflect and test this change as well as removal of URA data for corporate partners as not applicable