### PR TITLE
Make additional logging calls when the health check end-point is called

### DIFF
--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/HealthCheckLoggingFilter.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/HealthCheckLoggingFilter.java
@@ -1,0 +1,26 @@
+package uk.gov.companieshouse.officer.delta.processor.logging;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import java.io.IOException;
+
+@Component
+public class HealthCheckLoggingFilter implements Filter {
+    private static final Logger logger = LoggerFactory.getLogger(HealthCheckLoggingFilter.class);
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+            throws IOException, ServletException {
+
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+        if (httpRequest.getRequestURI().endsWith("/healthcheck")) {
+            logger.info("Health check endpoint was called from IP: {}", request.getRemoteAddr());
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/HealthCheckLoggingFilter.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/HealthCheckLoggingFilter.java
@@ -7,6 +7,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 import java.io.IOException;
 
+// NOTE: This code is temporary and will not be deployed to STAGING or LIVE. It is only to investigate a deployment
+//       issue in the CiDev environment
+
 @Component
 public class HealthCheckLoggingFilter implements Filter {
     private static final Logger logger = LoggerFactory.getLogger(HealthCheckLoggingFilter.class);

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/LoggingHealthIndicator.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/LoggingHealthIndicator.java
@@ -1,0 +1,20 @@
+package uk.gov.companieshouse.officer.delta.processor.logging;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.health.Health;
+import org.springframework.boot.actuate.health.HealthIndicator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LoggingHealthIndicator implements HealthIndicator {
+    private static final Logger logger = LoggerFactory.getLogger(LoggingHealthIndicator.class);
+
+    @Override
+    public Health health() {
+        logger.info("Health check logic is executing...");
+        Health health = Health.up().build();
+        logger.info("Health status: {}", health.getStatus());
+        return health;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/LoggingHealthIndicator.java
+++ b/src/main/java/uk/gov/companieshouse/officer/delta/processor/logging/LoggingHealthIndicator.java
@@ -6,6 +6,9 @@ import org.springframework.boot.actuate.health.Health;
 import org.springframework.boot.actuate.health.HealthIndicator;
 import org.springframework.stereotype.Component;
 
+// NOTE: This code is temporary and will not be deployed to STAGING or LIVE. It is only to investigate a deployment
+//       issue in the CiDev environment
+
 @Component
 public class LoggingHealthIndicator implements HealthIndicator {
     private static final Logger logger = LoggerFactory.getLogger(LoggingHealthIndicator.class);

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -12,7 +12,7 @@ management.endpoint.health.enabled=true
 management.endpoint.health.show-details=never
 management.endpoints.web.exposure.include=health
 management.endpoints.web.base-path=/officer-delta-processor
-management.endpoints.web.path-mapping.health=/healthcheck
+management.endpoints.web.path-mapping.health=healthcheck
 
 server.port=8080
 chs.internal.api.key=${CHS_INTERNAL_API_KEY:testkey}

--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -44,7 +44,7 @@ module "ecs-service" {
   use_task_container_healthcheck    = true
   healthcheck_path                  = local.healthcheck_path
   healthcheck_matcher               = local.healthcheck_matcher
-  health_check_grace_period_seconds = 240
+  health_check_grace_period_seconds = 480
 
   # Docker container details
   docker_registry   = var.docker_registry


### PR DESCRIPTION
* Changes to help understand failed deployments in the CiDev environment
* Logging changes will be reverted once cause is understood, hence not unit-tested
* Calls to the health check end-point will now be logged as well as the status
* Minor change to path-mapping.health config value
* Health check grace period increased to give server longer to come up before health is checked